### PR TITLE
feat(PEER-729): setup app provider with basic redux store

### DIFF
--- a/apps/kernel/management-shell-browser/src/app-providers.tsx
+++ b/apps/kernel/management-shell-browser/src/app-providers.tsx
@@ -1,0 +1,21 @@
+import { Suspense, type FC } from 'react';
+import { HelmetProvider } from 'react-helmet-async';
+import { Provider } from 'react-redux';
+import { BrowserRouter } from 'react-router-dom';
+import { ErrorBoundary } from './components/error-boundary';
+import './global.css';
+import { store } from './store';
+
+export const AppProviders: FC<{ children: React.ReactNode }> = ({ children }) => {
+  return (
+    <HelmetProvider>
+      <BrowserRouter>
+        <Suspense>
+          <ErrorBoundary fallback={null}>
+            <Provider store={store}>{children}</Provider>
+          </ErrorBoundary>
+        </Suspense>
+      </BrowserRouter>
+    </HelmetProvider>
+  );
+};

--- a/apps/kernel/management-shell-browser/src/app-router.tsx
+++ b/apps/kernel/management-shell-browser/src/app-router.tsx
@@ -1,0 +1,3 @@
+export const AppRouter = () => {
+  return <h1>TODO</h1>;
+};

--- a/apps/kernel/management-shell-browser/src/app.tsx
+++ b/apps/kernel/management-shell-browser/src/app.tsx
@@ -1,7 +1,0 @@
-import { type FC } from 'react';
-
-import '@peerlab/kernel/management-shell-browser/global.css';
-
-export const App: FC = () => {
-  return <h1>TODO</h1>;
-};

--- a/apps/kernel/management-shell-browser/src/main.tsx
+++ b/apps/kernel/management-shell-browser/src/main.tsx
@@ -1,24 +1,17 @@
-import { App } from '@peerlab/kernel/management-shell-browser/app';
-// import { FlagProvider } from '@unleash/proxy-client-react';
-import { Suspense } from 'react';
 import { createRoot } from 'react-dom/client';
-import { HelmetProvider } from 'react-helmet-async';
-import { BrowserRouter } from 'react-router-dom';
-import { ErrorBoundary } from './components/error-boundary';
-// import { unleashConfig } from './config';
+import { AppProviders } from './app-providers';
+import { AppRouter } from './app-router';
 
-const root = createRoot(document.getElementById('root') as HTMLElement);
+const rootContainer = document.getElementById('root');
+
+if (!rootContainer) {
+  throw Error('No root element found');
+}
+
+const root = createRoot(rootContainer);
 
 root.render(
-  <HelmetProvider>
-    <BrowserRouter>
-      <Suspense>
-        <ErrorBoundary fallback={<App />}>
-          {/* <FlagProvider config={unleashConfig}> */}
-          <App />
-          {/* </FlagProvider> */}
-        </ErrorBoundary>
-      </Suspense>
-    </BrowserRouter>
-  </HelmetProvider>,
+  <AppProviders>
+    <AppRouter />
+  </AppProviders>,
 );

--- a/apps/kernel/management-shell-browser/src/store/index.ts
+++ b/apps/kernel/management-shell-browser/src/store/index.ts
@@ -1,0 +1,5 @@
+import { configureStore } from '@reduxjs/toolkit';
+
+export const store = configureStore({
+  reducer: {},
+});

--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
     "react-markdown": "8.0.7",
     "react-quill": "2.0.0",
     "react-redux": "8.1.1",
-    "react-router": "6.15.0",
+    "react-router": "6.26.0",
     "react-router-dom": "6.14.1",
     "react-slick": "0.29.0",
     "react-spring": "9.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,8 +360,8 @@ importers:
         specifier: 8.1.1
         version: 8.1.1(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.74.3(@babel/core@7.14.5)(@babel/preset-env@7.25.0(@babel/core@7.24.9))(@types/react@18.3.1)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)(redux@4.2.1)
       react-router:
-        specifier: 6.15.0
-        version: 6.15.0(react@18.3.1)
+        specifier: 6.26.0
+        version: 6.26.0(react@18.3.1)
       react-router-dom:
         specifier: 6.14.1
         version: 6.14.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5273,13 +5273,13 @@ packages:
       react-redux:
         optional: true
 
+  '@remix-run/router@1.19.0':
+    resolution: {integrity: sha512-zDICCLKEwbVYTS6TjYaWtHXxkdoUvD/QXvyVZjGCsWz5vyH7aFeONlPffPdW+Y/t6KT0MgXb2Mfjun9YpWN1dA==}
+    engines: {node: '>=14.0.0'}
+
   '@remix-run/router@1.7.1':
     resolution: {integrity: sha512-bgVQM4ZJ2u2CM8k1ey70o1ePFXsEzYVZoWghh6WjM8p59jQ7HxzbHW4SbnWFG7V9ig9chLawQxDTZ3xzOF8MkQ==}
     engines: {node: '>=14'}
-
-  '@remix-run/router@1.8.0':
-    resolution: {integrity: sha512-mrfKqIHnSZRyIzBcanNJmVQELTnX+qagEDlcKO90RgRBVOZGSGvZKeDihTRfWcqoDn5N/NkUcwWTccnpN18Tfg==}
-    engines: {node: '>=14.0.0'}
 
   '@replit/codemirror-css-color-picker@6.2.0':
     resolution: {integrity: sha512-6SllcL7WTr6SyFj9WhMUFAgdmvg6kLOIiMSjhYXYRAmpDEgO9HZvMRLlXSP+4ciVmJyvt/qxZJQS8sPi5KhMeA==}
@@ -14672,8 +14672,8 @@ packages:
     peerDependencies:
       react: '>=16.8'
 
-  react-router@6.15.0:
-    resolution: {integrity: sha512-NIytlzvzLwJkCQj2HLefmeakxxWHWAP+02EGqWEZy+DgfHHKQMUoBBjUQLOtFInBMhWtb3hiUy6MfFgwLjXhqg==}
+  react-router@6.26.0:
+    resolution: {integrity: sha512-wVQq0/iFYd3iZ9H2l3N3k4PL8EEHcb0XlU2Na8nEwmiXgIUElEH6gaJDtUQxJ+JFzmIXaQjfdpcGWaM6IoQGxg==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
@@ -19722,13 +19722,6 @@ snapshots:
       regexpu-core: 5.3.2
       semver: 6.3.1
 
-  '@babel/helper-create-regexp-features-plugin@7.25.0(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-annotate-as-pure': 7.24.7
-      regexpu-core: 5.3.2
-      semver: 6.3.1
-
   '@babel/helper-define-polyfill-provider@0.6.2(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
@@ -19816,15 +19809,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-remap-async-to-generator@7.25.0(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-wrap-function': 7.25.0
-      '@babel/traverse': 7.25.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-replace-supers@7.25.0(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
@@ -19895,32 +19879,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.25.0(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/traverse': 7.25.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.25.0(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.25.0(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.25.0(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.25.0(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.7(@babel/core@7.14.5)':
@@ -19932,26 +19898,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
-      '@babel/plugin-transform-optional-chaining': 7.24.8(@babel/core@7.24.9)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.25.0(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/traverse': 7.25.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.25.0(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/traverse': 7.25.1
     transitivePeerDependencies:
@@ -20052,18 +20001,9 @@ snapshots:
     dependencies:
       '@babel/core': 7.14.5
 
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-
   '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.14.5)':
@@ -20076,19 +20016,9 @@ snapshots:
       '@babel/core': 7.14.5
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-decorators@7.24.7(@babel/core@7.14.5)':
@@ -20121,11 +20051,6 @@ snapshots:
       '@babel/core': 7.14.5
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-flow@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
@@ -20141,19 +20066,9 @@ snapshots:
       '@babel/core': 7.14.5
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-import-assertions@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-import-attributes@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-syntax-import-attributes@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.14.5)':
@@ -20161,19 +20076,9 @@ snapshots:
       '@babel/core': 7.14.5
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-jsx@7.12.1(@babel/core@7.12.9)':
@@ -20196,29 +20101,14 @@ snapshots:
       '@babel/core': 7.14.5
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.12.9)':
@@ -20231,19 +20121,9 @@ snapshots:
       '@babel/core': 7.14.5
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.14.5)':
@@ -20251,29 +20131,14 @@ snapshots:
       '@babel/core': 7.14.5
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-syntax-typescript@7.24.7(@babel/core@7.14.5)':
@@ -20292,20 +20157,9 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.25.0(@babel/core@7.14.5)
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-create-regexp-features-plugin': 7.25.0(@babel/core@7.24.9)
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-arrow-functions@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-arrow-functions@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-async-generator-functions@7.25.0(@babel/core@7.14.5)':
@@ -20314,16 +20168,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-remap-async-to-generator': 7.25.0(@babel/core@7.14.5)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.14.5)
-      '@babel/traverse': 7.25.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-async-generator-functions@7.25.0(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-remap-async-to-generator': 7.25.0(@babel/core@7.24.9)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.9)
       '@babel/traverse': 7.25.1
     transitivePeerDependencies:
       - supports-color
@@ -20337,33 +20181,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-async-to-generator@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-module-imports': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-remap-async-to-generator': 7.25.0(@babel/core@7.24.9)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-block-scoped-functions@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-block-scoped-functions@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-block-scoping@7.25.0(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-block-scoping@7.25.0(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-class-properties@7.24.7(@babel/core@7.14.5)':
@@ -20377,7 +20202,7 @@ snapshots:
   '@babel/plugin-transform-class-properties@7.24.7(@babel/core@7.24.9)':
     dependencies:
       '@babel/core': 7.24.9
-      '@babel/helper-create-class-features-plugin': 7.25.0(@babel/core@7.24.9)
+      '@babel/helper-create-class-features-plugin': 7.25.0(@babel/core@7.14.5)
       '@babel/helper-plugin-utils': 7.24.8
     transitivePeerDependencies:
       - supports-color
@@ -20388,15 +20213,6 @@ snapshots:
       '@babel/helper-create-class-features-plugin': 7.25.0(@babel/core@7.14.5)
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.14.5)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-class-static-block@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-create-class-features-plugin': 7.25.0(@babel/core@7.24.9)
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -20412,27 +20228,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-classes@7.25.0(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-compilation-targets': 7.24.8
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-replace-supers': 7.25.0(@babel/core@7.24.9)
-      '@babel/traverse': 7.25.1
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-computed-properties@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/template': 7.25.0
-
-  '@babel/plugin-transform-computed-properties@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/template': 7.25.0
 
@@ -20441,31 +20239,15 @@ snapshots:
       '@babel/core': 7.14.5
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-destructuring@7.24.8(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-dotall-regex@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
       '@babel/helper-create-regexp-features-plugin': 7.25.0(@babel/core@7.14.5)
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-dotall-regex@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-create-regexp-features-plugin': 7.25.0(@babel/core@7.24.9)
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-duplicate-keys@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-duplicate-keys@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.25.0(@babel/core@7.14.5)':
@@ -20474,35 +20256,15 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.25.0(@babel/core@7.14.5)
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.25.0(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-create-regexp-features-plugin': 7.25.0(@babel/core@7.24.9)
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-dynamic-import@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.14.5)
 
-  '@babel/plugin-transform-dynamic-import@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.9)
-
   '@babel/plugin-transform-exponentiation-operator@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-builder-binary-assignment-operator-visitor': 7.24.7
-      '@babel/helper-plugin-utils': 7.24.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-exponentiation-operator@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-builder-binary-assignment-operator-visitor': 7.24.7
       '@babel/helper-plugin-utils': 7.24.8
     transitivePeerDependencies:
@@ -20513,12 +20275,6 @@ snapshots:
       '@babel/core': 7.14.5
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.14.5)
-
-  '@babel/plugin-transform-export-namespace-from@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.9)
 
   '@babel/plugin-transform-flow-strip-types@7.24.7(@babel/core@7.14.5)':
     dependencies:
@@ -20540,26 +20296,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-for-of@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-function-name@7.25.1(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-compilation-targets': 7.24.8
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/traverse': 7.25.1
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-function-name@7.25.1(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-compilation-targets': 7.24.8
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/traverse': 7.25.1
@@ -20572,20 +20311,9 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.14.5)
 
-  '@babel/plugin-transform-json-strings@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.9)
-
   '@babel/plugin-transform-literals@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-literals@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-logical-assignment-operators@7.24.7(@babel/core@7.14.5)':
@@ -20594,34 +20322,15 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.14.5)
 
-  '@babel/plugin-transform-logical-assignment-operators@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.9)
-
   '@babel/plugin-transform-member-expression-literals@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-member-expression-literals@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-modules-amd@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
       '@babel/helper-module-transforms': 7.25.0(@babel/core@7.14.5)
-      '@babel/helper-plugin-utils': 7.24.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-amd@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-module-transforms': 7.25.0(@babel/core@7.24.9)
       '@babel/helper-plugin-utils': 7.24.8
     transitivePeerDependencies:
       - supports-color
@@ -20654,28 +20363,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.25.0(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-module-transforms': 7.25.0(@babel/core@7.24.9)
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-validator-identifier': 7.24.7
-      '@babel/traverse': 7.25.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-modules-umd@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
       '@babel/helper-module-transforms': 7.25.0(@babel/core@7.14.5)
-      '@babel/helper-plugin-utils': 7.24.8
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-umd@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-module-transforms': 7.25.0(@babel/core@7.24.9)
       '@babel/helper-plugin-utils': 7.24.8
     transitivePeerDependencies:
       - supports-color
@@ -20686,20 +20377,9 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.25.0(@babel/core@7.14.5)
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-named-capturing-groups-regex@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-create-regexp-features-plugin': 7.25.0(@babel/core@7.24.9)
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-new-target@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-new-target@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.24.7(@babel/core@7.14.5)':
@@ -20712,19 +20392,13 @@ snapshots:
     dependencies:
       '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.9)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.14.5)
 
   '@babel/plugin-transform-numeric-separator@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.14.5)
-
-  '@babel/plugin-transform-numeric-separator@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.9)
 
   '@babel/plugin-transform-object-rest-spread@7.24.7(@babel/core@7.14.5)':
     dependencies:
@@ -20734,14 +20408,6 @@ snapshots:
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.14.5)
       '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.14.5)
 
-  '@babel/plugin-transform-object-rest-spread@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-compilation-targets': 7.24.8
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.9)
-      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.9)
-
   '@babel/plugin-transform-object-super@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
@@ -20750,25 +20416,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-object-super@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-replace-supers': 7.25.0(@babel/core@7.24.9)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-optional-catch-binding@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.14.5)
-
-  '@babel/plugin-transform-optional-catch-binding@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.9)
 
   '@babel/plugin-transform-optional-chaining@7.24.8(@babel/core@7.14.5)':
     dependencies:
@@ -20784,7 +20436,7 @@ snapshots:
       '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.9)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.14.5)
     transitivePeerDependencies:
       - supports-color
 
@@ -20796,11 +20448,6 @@ snapshots:
   '@babel/plugin-transform-parameters@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-parameters@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-private-methods@7.24.7(@babel/core@7.14.5)':
@@ -20829,24 +20476,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-private-property-in-object@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-annotate-as-pure': 7.24.7
-      '@babel/helper-create-class-features-plugin': 7.25.0(@babel/core@7.24.9)
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.9)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-property-literals@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-property-literals@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-react-constant-elements@7.25.1(@babel/core@7.24.9)':
@@ -20938,20 +20570,9 @@ snapshots:
       '@babel/helper-plugin-utils': 7.24.8
       regenerator-transform: 0.15.2
 
-  '@babel/plugin-transform-regenerator@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-      regenerator-transform: 0.15.2
-
   '@babel/plugin-transform-reserved-words@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-reserved-words@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-runtime@7.24.7(@babel/core@7.14.5)':
@@ -20983,22 +20604,9 @@ snapshots:
       '@babel/core': 7.14.5
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-shorthand-properties@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-spread@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-spread@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-skip-transparent-expression-wrappers': 7.24.7
     transitivePeerDependencies:
@@ -21009,29 +20617,14 @@ snapshots:
       '@babel/core': 7.14.5
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-sticky-regex@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-template-literals@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-template-literals@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-typeof-symbol@7.24.8(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-typeof-symbol@7.24.8(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-typescript@7.25.0(@babel/core@7.14.5)':
@@ -21061,21 +20654,10 @@ snapshots:
       '@babel/core': 7.14.5
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-unicode-escapes@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-unicode-property-regex@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
       '@babel/helper-create-regexp-features-plugin': 7.25.0(@babel/core@7.14.5)
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-unicode-property-regex@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-create-regexp-features-plugin': 7.25.0(@babel/core@7.24.9)
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/plugin-transform-unicode-regex@7.24.7(@babel/core@7.14.5)':
@@ -21084,22 +20666,10 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.25.0(@babel/core@7.14.5)
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-transform-unicode-regex@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-create-regexp-features-plugin': 7.25.0(@babel/core@7.24.9)
-      '@babel/helper-plugin-utils': 7.24.8
-
   '@babel/plugin-transform-unicode-sets-regex@7.24.7(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
       '@babel/helper-create-regexp-features-plugin': 7.25.0(@babel/core@7.14.5)
-      '@babel/helper-plugin-utils': 7.24.8
-
-  '@babel/plugin-transform-unicode-sets-regex@7.24.7(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
-      '@babel/helper-create-regexp-features-plugin': 7.25.0(@babel/core@7.24.9)
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/preset-env@7.25.0(@babel/core@7.14.5)':
@@ -21198,83 +20768,83 @@ snapshots:
       '@babel/helper-compilation-targets': 7.24.8
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/helper-validator-option': 7.24.8
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.25.0(@babel/core@7.24.9)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.25.0(@babel/core@7.24.9)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.25.0(@babel/core@7.24.9)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.25.0(@babel/core@7.24.9)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.24.9)
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.24.9)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.24.9)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.24.9)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.24.9)
-      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.24.9)
-      '@babel/plugin-syntax-import-assertions': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-syntax-import-attributes': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.24.9)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.24.9)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.24.9)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.24.9)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.24.9)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.24.9)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.24.9)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.24.9)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.24.9)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.24.9)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.24.9)
-      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-async-generator-functions': 7.25.0(@babel/core@7.24.9)
-      '@babel/plugin-transform-async-to-generator': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-block-scoped-functions': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-block-scoping': 7.25.0(@babel/core@7.24.9)
-      '@babel/plugin-transform-class-properties': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-class-static-block': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-classes': 7.25.0(@babel/core@7.24.9)
-      '@babel/plugin-transform-computed-properties': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-destructuring': 7.24.8(@babel/core@7.24.9)
-      '@babel/plugin-transform-dotall-regex': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-duplicate-keys': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.25.0(@babel/core@7.24.9)
-      '@babel/plugin-transform-dynamic-import': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-exponentiation-operator': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-export-namespace-from': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-for-of': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-function-name': 7.25.1(@babel/core@7.24.9)
-      '@babel/plugin-transform-json-strings': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-literals': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-logical-assignment-operators': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-member-expression-literals': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-modules-amd': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.24.9)
-      '@babel/plugin-transform-modules-systemjs': 7.25.0(@babel/core@7.24.9)
-      '@babel/plugin-transform-modules-umd': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-new-target': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-numeric-separator': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-object-rest-spread': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-object-super': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-optional-catch-binding': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-optional-chaining': 7.24.8(@babel/core@7.24.9)
-      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-private-methods': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-private-property-in-object': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-property-literals': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-regenerator': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-reserved-words': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-spread': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-sticky-regex': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-template-literals': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-typeof-symbol': 7.24.8(@babel/core@7.24.9)
-      '@babel/plugin-transform-unicode-escapes': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-unicode-property-regex': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-unicode-regex': 7.24.7(@babel/core@7.24.9)
-      '@babel/plugin-transform-unicode-sets-regex': 7.24.7(@babel/core@7.24.9)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.24.9)
-      babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.24.9)
-      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.24.9)
-      babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.24.9)
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.25.0(@babel/core@7.14.5)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.25.0(@babel/core@7.14.5)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.25.0(@babel/core@7.14.5)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.25.0(@babel/core@7.14.5)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.14.5)
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.14.5)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.14.5)
+      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.14.5)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.14.5)
+      '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.14.5)
+      '@babel/plugin-syntax-import-assertions': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-syntax-import-attributes': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.14.5)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.14.5)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.14.5)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.14.5)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.14.5)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.14.5)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.14.5)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.14.5)
+      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.14.5)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.14.5)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.14.5)
+      '@babel/plugin-transform-arrow-functions': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-async-generator-functions': 7.25.0(@babel/core@7.14.5)
+      '@babel/plugin-transform-async-to-generator': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-block-scoped-functions': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-block-scoping': 7.25.0(@babel/core@7.14.5)
+      '@babel/plugin-transform-class-properties': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-class-static-block': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-classes': 7.25.0(@babel/core@7.14.5)
+      '@babel/plugin-transform-computed-properties': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-destructuring': 7.24.8(@babel/core@7.14.5)
+      '@babel/plugin-transform-dotall-regex': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-duplicate-keys': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.25.0(@babel/core@7.14.5)
+      '@babel/plugin-transform-dynamic-import': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-exponentiation-operator': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-export-namespace-from': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-for-of': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-function-name': 7.25.1(@babel/core@7.14.5)
+      '@babel/plugin-transform-json-strings': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-literals': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-logical-assignment-operators': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-member-expression-literals': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-modules-amd': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-modules-commonjs': 7.24.8(@babel/core@7.14.5)
+      '@babel/plugin-transform-modules-systemjs': 7.25.0(@babel/core@7.14.5)
+      '@babel/plugin-transform-modules-umd': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-new-target': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-numeric-separator': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-object-rest-spread': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-object-super': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-optional-catch-binding': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-optional-chaining': 7.24.8(@babel/core@7.14.5)
+      '@babel/plugin-transform-parameters': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-private-methods': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-private-property-in-object': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-property-literals': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-regenerator': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-reserved-words': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-shorthand-properties': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-spread': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-sticky-regex': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-template-literals': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-typeof-symbol': 7.24.8(@babel/core@7.14.5)
+      '@babel/plugin-transform-unicode-escapes': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-unicode-property-regex': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-unicode-regex': 7.24.7(@babel/core@7.14.5)
+      '@babel/plugin-transform-unicode-sets-regex': 7.24.7(@babel/core@7.14.5)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.14.5)
+      babel-plugin-polyfill-corejs2: 0.4.11(@babel/core@7.14.5)
+      babel-plugin-polyfill-corejs3: 0.10.4(@babel/core@7.14.5)
+      babel-plugin-polyfill-regenerator: 0.6.2(@babel/core@7.14.5)
       core-js-compat: 3.37.1
       semver: 6.3.1
     transitivePeerDependencies:
@@ -21297,13 +20867,6 @@ snapshots:
   '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.14.5)':
     dependencies:
       '@babel/core': 7.14.5
-      '@babel/helper-plugin-utils': 7.24.8
-      '@babel/types': 7.25.0
-      esutils: 2.0.3
-
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.24.9)':
-    dependencies:
-      '@babel/core': 7.24.9
       '@babel/helper-plugin-utils': 7.24.8
       '@babel/types': 7.25.0
       esutils: 2.0.3
@@ -26459,9 +26022,9 @@ snapshots:
       react: 18.3.1
       react-redux: 8.1.1(@types/react-dom@18.3.0)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react-native@0.74.3(@babel/core@7.14.5)(@babel/preset-env@7.25.0(@babel/core@7.24.9))(@types/react@18.3.1)(encoding@0.1.13)(react@18.3.1))(react@18.3.1)(redux@4.2.1)
 
-  '@remix-run/router@1.7.1': {}
+  '@remix-run/router@1.19.0': {}
 
-  '@remix-run/router@1.8.0': {}
+  '@remix-run/router@1.7.1': {}
 
   '@replit/codemirror-css-color-picker@6.2.0(@codemirror/language@6.10.2)(@codemirror/state@6.4.1)(@codemirror/view@6.29.0)':
     dependencies:
@@ -38811,9 +38374,9 @@ snapshots:
       '@remix-run/router': 1.7.1
       react: 18.3.1
 
-  react-router@6.15.0(react@18.3.1):
+  react-router@6.26.0(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.8.0
+      '@remix-run/router': 1.19.0
       react: 18.3.1
 
   react-shallow-renderer@16.15.0(react@18.3.1):


### PR DESCRIPTION
# What and why was modified?

- Redux with react-redux and @redux/toolkit added to kernel-management-shell-browser application;
  - To prepare development of browser app with non proprietary code.
- Files were renamed;
  - To separate app-router from app-providers;