### PR TITLE
fix(PEER-752): reproduce type error

### DIFF
--- a/apps/kernel/management-shell-browser/src/app-router.tsx
+++ b/apps/kernel/management-shell-browser/src/app-router.tsx
@@ -1,3 +1,4 @@
+import { lazy } from 'react';
 import { RouteObject, createBrowserRouter } from 'react-router-dom';
 import { ErrorBoundary } from '../../shared-ui-components/src/lib/errors/error-boundary';
 import { reduxUserSessionRepository } from './domains/people/user-session/adapters/redux-repository';
@@ -10,15 +11,21 @@ import { HomePage } from './domains/search/pages/home';
 import { Layout } from './domains/shared/components/layout';
 import { Dashboard } from './domains/shared/pages/dashboard';
 
+const PublicPage = lazy(() => import('./domains/shared/pages/public'));
+
 export const routes: Array<RouteObject> = [
   {
     path: '/',
     element: <Layout />,
-    errorElement: <ErrorBoundary fallback={null} />,
+    errorElement: <ErrorBoundary fallback={<h1>Router Error Boundary</h1>} />,
     children: [
       {
         index: true,
         element: <HomePage />,
+      },
+      {
+        path: 'public',
+        element: <PublicPage />,
       },
       {
         path: 'auth/sign-in',
@@ -46,3 +53,5 @@ export type IRouter = typeof browserRouter;
 if (import.meta.hot) {
   import.meta.hot.dispose(() => browserRouter.dispose());
 }
+
+// Give me a docker command to run a docker container with node 18 image and serve the index.html file under dist/apps/kernel/management-shell-browser folder

--- a/apps/kernel/management-shell-browser/src/domains/shared/components/layout/index.tsx
+++ b/apps/kernel/management-shell-browser/src/domains/shared/components/layout/index.tsx
@@ -14,6 +14,9 @@ export const Layout = () => {
           <li>
             <Link to="workspaces">Workspaces Dashboard</Link>
           </li>
+          <li>
+            <Link to="public">Public Page</Link>
+          </li>
           {auth.isAuthenticated && <button onClick={() => auth.removeUser()}>Log out</button>}
         </ul>
       </nav>

--- a/apps/kernel/management-shell-browser/src/domains/shared/pages/public/index.tsx
+++ b/apps/kernel/management-shell-browser/src/domains/shared/pages/public/index.tsx
@@ -1,0 +1,5 @@
+const PublicPage = () => {
+  return <h1>Dynamic Public Page V1</h1>;
+};
+
+export default PublicPage;

--- a/apps/kernel/management-shell-browser/vite.config.ts
+++ b/apps/kernel/management-shell-browser/vite.config.ts
@@ -4,6 +4,21 @@ import path from 'node:path';
 import { defineConfig, searchForWorkspaceRoot } from 'vite';
 import viteTsConfigPaths from 'vite-tsconfig-paths';
 
+const deriveFileNameFromChunkInfo = (chunkInfo: { facadeModuleId: string | null }): string => {
+  if (!chunkInfo.facadeModuleId) {
+    return 'assets/js/[name]-[hash].js';
+  }
+
+  const basename = path.basename(chunkInfo.facadeModuleId);
+  if (basename.startsWith('@')) {
+    return 'assets/js/[name]-[hash].js';
+  }
+
+  const ext = path.extname(chunkInfo.facadeModuleId);
+  const outputFileName = chunkInfo.facadeModuleId.replace(__dirname, 'assets/js').replace(ext, '.js');
+  return outputFileName;
+};
+
 export default defineConfig({
   root: __dirname,
   build: {
@@ -11,6 +26,13 @@ export default defineConfig({
     reportCompressedSize: true,
     commonjsOptions: {
       transformMixedEsModules: true,
+    },
+    rollupOptions: {
+      output: {
+        chunkFileNames: deriveFileNameFromChunkInfo,
+        entryFileNames: deriveFileNameFromChunkInfo,
+        assetFileNames: 'assets/[ext]/[name].[ext]',
+      },
     },
   },
   cacheDir: '../../../node_modules/.vite/kernel-management-shell-browser',


### PR DESCRIPTION
# What and why was modified?

- Dynamic imported module added using [React.lazy](https://react.dev/reference/react/lazy) to try to reproduce and fix the issue https://github.com/vitejs/vite/issues/11804 for the following use case:
  - WHEN user loads initial page before a new deployment is made;
  - AND a new deployment removes a dynamically imported module that was referenced in the previous deployment;
  - AND user clicks a link that is available in his stale version;
  - THEN user experiences an error `TypeError: Failed to fetch dynamically imported module`;
- Chunk file name and path outputs were customized using [rollulpOptions](https://rollupjs.org/configuration-options/#output-chunkfilenames) to avoid the file update issue;
- A fallback component was added to the router error component;
