### PR TITLE
feat(PEER-755): add hierarchical relationships between taxons

### DIFF
--- a/apps/kernel/shared-ts-utils/src/costs/index.ts
+++ b/apps/kernel/shared-ts-utils/src/costs/index.ts
@@ -7,7 +7,7 @@ abstract class AbstractCostManager {
 const costStructurePerGbInUSD = {
   logging: {
     traffic: 0,
-    monthlyStorage: 0.5
+    monthlyStorage: 0.5,
   },
 } as const;
 

--- a/apps/kernel/shared-ts-utils/src/date-formats.ts
+++ b/apps/kernel/shared-ts-utils/src/date-formats.ts
@@ -1,3 +1,8 @@
 export const iso8601DateFormat = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/;
 export const firebaseIdFormat = /^[A-Za-z0-9]{24,28}$/;
 export const mongoDbIdFormat = /^[0-9a-fA-F]{24}$/;
+export const lineageIdPathFormat = /^[/][0-9a-fA-F]{24}(?:\/[0-9a-fA-F]{24})*$/;
+
+export const idPathEndingWithId = (id: string) => {
+  return new RegExp(`^/[0-9a-fA-F]{24}(?:/[0-9a-fA-F]{24})*/${id}$`);
+};

--- a/apps/kernel/taxonomic-units/base/src/config/configuration-management.ts
+++ b/apps/kernel/taxonomic-units/base/src/config/configuration-management.ts
@@ -24,7 +24,7 @@ export class ConfigurationManager {
   };
   useCases?: {
     createFirstVersionOfTaxonomicUnitV1UseCase: CreateFirstVersionOfTaxonomicUnitV1UseCase;
-    filterOrganizationsV1: FilterTaxonomicUnitsV1UseCase;
+    filterTaxonomicUnitsV1UseCase: FilterTaxonomicUnitsV1UseCase;
     getTaxonomicUnitV1ById: GetTaxonomicUnitV1ByIdUseCase;
     createTaxonomicUnitV1Instance: CreateTaxonomicUnitV1InstanceUseCase;
   };
@@ -107,7 +107,7 @@ export class ConfigurationManager {
         this.repositories.taxonomicUnitsV1,
       ),
       getTaxonomicUnitV1ById: new GetTaxonomicUnitV1ByIdUseCase(this.repositories.taxonomicUnitsV1),
-      filterOrganizationsV1: new FilterTaxonomicUnitsV1UseCase(this.repositories.taxonomicUnitsV1),
+      filterTaxonomicUnitsV1UseCase: new FilterTaxonomicUnitsV1UseCase(this.repositories.taxonomicUnitsV1),
       createTaxonomicUnitV1Instance: new CreateTaxonomicUnitV1InstanceUseCase(
         this.repositories.taxonomicUnitsV1,
         this.repositories.taxonomicUnitInstancesV1,

--- a/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-instance-v1/core/entity.schema.ts
+++ b/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-instance-v1/core/entity.schema.ts
@@ -1,4 +1,3 @@
-import jsonSchemaMetaSchemaV4 from '@peerlab/kernel/shared-ts-utils/validators/json-schema-draft-04.schema';
 import { JSONSchema } from 'json-schema-to-typescript';
 
 const taxonomicUnitInstanceV1JsonSchema = {
@@ -20,7 +19,9 @@ const taxonomicUnitInstanceV1JsonSchema = {
       additionalProperties: false,
       required: ['name', 'version'],
     },
-    data: jsonSchemaMetaSchemaV4,
+    data: {
+      $ref: 'http://json-schema.org/draft-04/schema#',
+    },
   },
   required: ['data', 'schema', 'id'],
   additionalProperties: false,

--- a/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-instance-v1/core/entity.schema.types.d.ts
+++ b/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-instance-v1/core/entity.schema.types.d.ts
@@ -5,6 +5,15 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
+/**
+ * @minItems 1
+ */
+export type SchemaArray = [HttpJsonSchemaOrgDraft04Schema, ...HttpJsonSchemaOrgDraft04Schema[]];
+/**
+ * @minItems 1
+ */
+export type StringArray = [string, ...string[]];
+
 export interface ITaxonomicUnitInstanceV1 {
   /**
    * The unique identifier of a taxonomic unit as a hexadecimal string of 24 characters.
@@ -14,7 +23,60 @@ export interface ITaxonomicUnitInstanceV1 {
     version: number;
     name: string;
   };
-  data: {
-    [k: string]: unknown;
+  data: HttpJsonSchemaOrgDraft04Schema;
+}
+/**
+ * Core schema meta-schema
+ */
+export interface HttpJsonSchemaOrgDraft04Schema {
+  id?: string;
+  $schema?: string;
+  title?: string;
+  description?: string;
+  default?: unknown;
+  multipleOf?: number;
+  maximum?: number;
+  exclusiveMaximum?: boolean;
+  minimum?: number;
+  exclusiveMinimum?: boolean;
+  maxLength?: number;
+  minLength?: number;
+  pattern?: string;
+  additionalItems?: boolean | HttpJsonSchemaOrgDraft04Schema;
+  items?: HttpJsonSchemaOrgDraft04Schema | SchemaArray;
+  maxItems?: number;
+  minItems?: number;
+  uniqueItems?: boolean;
+  maxProperties?: number;
+  minProperties?: number;
+  required?: StringArray;
+  additionalProperties?: boolean | HttpJsonSchemaOrgDraft04Schema;
+  definitions?: {
+    [k: string]: HttpJsonSchemaOrgDraft04Schema;
   };
+  properties?: {
+    [k: string]: HttpJsonSchemaOrgDraft04Schema;
+  };
+  patternProperties?: {
+    [k: string]: HttpJsonSchemaOrgDraft04Schema;
+  };
+  dependencies?: {
+    [k: string]: HttpJsonSchemaOrgDraft04Schema | StringArray;
+  };
+  /**
+   * @minItems 1
+   */
+  enum?: [unknown, ...unknown[]];
+  type?:
+    | ("array" | "boolean" | "integer" | "null" | "number" | "object" | "string")
+    | [
+        "array" | "boolean" | "integer" | "null" | "number" | "object" | "string",
+        ...("array" | "boolean" | "integer" | "null" | "number" | "object" | "string")[]
+      ];
+  format?: string;
+  allOf?: SchemaArray;
+  anyOf?: SchemaArray;
+  oneOf?: SchemaArray;
+  not?: HttpJsonSchemaOrgDraft04Schema;
+  [k: string]: unknown;
 }

--- a/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-instance-v1/core/use-cases/create-instance/input-dto.schema.types.d.ts
+++ b/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-instance-v1/core/use-cases/create-instance/input-dto.schema.types.d.ts
@@ -5,12 +5,74 @@
  * and run json-schema-to-typescript to regenerate this file.
  */
 
+/**
+ * @minItems 1
+ */
+export type SchemaArray = [HttpJsonSchemaOrgDraft04Schema, ...HttpJsonSchemaOrgDraft04Schema[]];
+/**
+ * @minItems 1
+ */
+export type StringArray = [string, ...string[]];
+
 export interface ICreateTaxonomicUnitV1InstanceInputDto {
   schema: {
-    name: string;
     version: number;
+    name: string;
   };
-  data: {
-    [k: string]: unknown;
+  data: HttpJsonSchemaOrgDraft04Schema;
+}
+/**
+ * Core schema meta-schema
+ */
+export interface HttpJsonSchemaOrgDraft04Schema {
+  id?: string;
+  $schema?: string;
+  title?: string;
+  description?: string;
+  default?: unknown;
+  multipleOf?: number;
+  maximum?: number;
+  exclusiveMaximum?: boolean;
+  minimum?: number;
+  exclusiveMinimum?: boolean;
+  maxLength?: number;
+  minLength?: number;
+  pattern?: string;
+  additionalItems?: boolean | HttpJsonSchemaOrgDraft04Schema;
+  items?: HttpJsonSchemaOrgDraft04Schema | SchemaArray;
+  maxItems?: number;
+  minItems?: number;
+  uniqueItems?: boolean;
+  maxProperties?: number;
+  minProperties?: number;
+  required?: StringArray;
+  additionalProperties?: boolean | HttpJsonSchemaOrgDraft04Schema;
+  definitions?: {
+    [k: string]: HttpJsonSchemaOrgDraft04Schema;
   };
+  properties?: {
+    [k: string]: HttpJsonSchemaOrgDraft04Schema;
+  };
+  patternProperties?: {
+    [k: string]: HttpJsonSchemaOrgDraft04Schema;
+  };
+  dependencies?: {
+    [k: string]: HttpJsonSchemaOrgDraft04Schema | StringArray;
+  };
+  /**
+   * @minItems 1
+   */
+  enum?: [unknown, ...unknown[]];
+  type?:
+    | ("array" | "boolean" | "integer" | "null" | "number" | "object" | "string")
+    | [
+        "array" | "boolean" | "integer" | "null" | "number" | "object" | "string",
+        ...("array" | "boolean" | "integer" | "null" | "number" | "object" | "string")[]
+      ];
+  format?: string;
+  allOf?: SchemaArray;
+  anyOf?: SchemaArray;
+  oneOf?: SchemaArray;
+  not?: HttpJsonSchemaOrgDraft04Schema;
+  [k: string]: unknown;
 }

--- a/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/adapters/rest-express-error-handler.ts
+++ b/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/adapters/rest-express-error-handler.ts
@@ -2,7 +2,11 @@ import { ILogMetadata } from '@peerlab/kernel/shared-ts-utils/logs/application-l
 import { winstonLogger } from '@peerlab/kernel/shared-ts-utils/logs/winston-logger';
 import express from 'express';
 import { ITaxonomicUnitV1 } from '../core/entity.schema.types';
-import { TaxonomicUnitV1NotFoundError } from '../core/errors';
+import {
+  DuplicatedTaxonomicUnitV1NameError,
+  ParentTaxonomicUnitNotFoundError,
+  TaxonomicUnitV1NotFoundError,
+} from '../core/errors';
 
 export class RestExpressTaxonomicUnitV1ResponseHandler {
   static async handleGetByIdSuccess(entityDto: ITaxonomicUnitV1, res: express.Response, log: ILogMetadata) {
@@ -14,13 +18,22 @@ export class RestExpressTaxonomicUnitV1ResponseHandler {
     return res.status(201).json(entityDto);
   }
 
-  static async handleNotFoundError(error: unknown, res: express.Response, log: ILogMetadata) {
+  static async handleErrors(error: unknown, res: express.Response, log: ILogMetadata) {
     if (res.writableEnded) {
       return;
     }
     if (error instanceof TaxonomicUnitV1NotFoundError) {
       winstonLogger.warn(error.message, log);
       return res.status(404).json({ message: error.message });
+    }
+    if (error instanceof ParentTaxonomicUnitNotFoundError) {
+      winstonLogger.warn(error.message, log);
+      return res.status(404).json({ message: error.message });
+    }
+
+    if (error instanceof DuplicatedTaxonomicUnitV1NameError) {
+      winstonLogger.warn(error.message, log);
+      return res.status(409).json({ message: error.message });
     }
   }
 }

--- a/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/entity.schema.ts
+++ b/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/entity.schema.ts
@@ -12,9 +12,15 @@ const taxonomicUnitV1JsonSchema = {
     },
     version: { type: 'integer', minimum: 1 },
     name: { type: 'string', pattern: '^(?:[a-z0-9]+(?:-[a-z0-9]+)*){4,}$' },
+    lineageIdPath: {
+      type: 'string',
+      description:
+        'The taxonomic lineage of a taxon (taxonomic unit) from the root to the taxon itself, as represented by a path of ids in the hierarchy',
+      pattern: '^/([0-9a-fA-F]{24})(?:/([0-9a-fA-F]{24}))*$',
+    },
     schema: { $ref: 'http://json-schema.org/draft-04/schema#' }, // First you should add the $ref as a key to ajv meta schema
   },
-  required: ['name', 'schema', 'version', 'id'],
+  required: ['name', 'schema', 'version', 'id', 'lineageIdPath'],
   additionalProperties: false,
 } as const satisfies JSONSchema; // TODO: if we use v7 here the type generator will not work currently
 

--- a/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/entity.schema.types.d.ts
+++ b/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/entity.schema.types.d.ts
@@ -21,6 +21,10 @@ export interface ITaxonomicUnitV1 {
   id: string;
   version: number;
   name: string;
+  /**
+   * The taxonomic lineage of a taxon (taxonomic unit) from the root to the taxon itself, as represented by a path of ids in the hierarchy
+   */
+  lineageIdPath: string;
   schema: HttpJsonSchemaOrgDraft04Schema;
 }
 /**

--- a/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/entity.spec.ts
+++ b/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/entity.spec.ts
@@ -10,6 +10,7 @@ describe('TaxonomicUnitV1Entity', () => {
       id: validId,
       version: 1,
       name: 'valid-taxonomic-unit-name',
+      lineageIdPath: `/${validId}`,
       schema: {
         properties: {
           parentId: {
@@ -24,6 +25,7 @@ describe('TaxonomicUnitV1Entity', () => {
       id: validId,
       version: 1,
       name: 'valid-taxonomic-unit-name',
+      lineageIdPath: `/${validId}`,
       schema: {
         properties: {
           parentId: {
@@ -42,6 +44,7 @@ describe('TaxonomicUnitV1Entity', () => {
           id: validId,
           version: invalidVersion,
           name: 'valid-taxonomic-unit-name',
+          lineageIdPath: `/${validId}`,
           schema: {
             properties: {
               parentId: {
@@ -59,6 +62,7 @@ describe('TaxonomicUnitV1Entity', () => {
       () =>
         new TaxonomicUnitV1Entity({
           id: validId,
+          lineageIdPath: `/${validId}`,
           version: 1,
           name: invalidName,
           schema: {

--- a/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/entity.ts
+++ b/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/entity.ts
@@ -6,7 +6,7 @@ import { ITaxonomicUnitV1 } from './entity.schema.types';
 export class TaxonomicUnitV1Entity {
   private dto: ITaxonomicUnitV1;
 
-  constructor(inputDto: ITaxonomicUnitV1) {
+  constructor(inputDto: ITaxonomicUnitV1, parentTaxonomicUnit: ITaxonomicUnitV1 = null) {
     TaxonomicUnitV1Entity.validate(inputDto);
     this.dto = inputDto;
   }

--- a/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/errors.ts
+++ b/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/errors.ts
@@ -5,3 +5,5 @@ export class DuplicatedTaxonomicUnitIdError extends Error {}
 export class UniqueTaxonomicUnitV1NameAndVersionError extends Error {}
 
 export class TaxonomicUnitV1NotFoundError extends Error {}
+
+export class ParentTaxonomicUnitNotFoundError extends Error {}

--- a/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/fixtures.ts
+++ b/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/fixtures.ts
@@ -2,10 +2,12 @@ import { faker } from '@faker-js/faker';
 import { TaxonomicUnitV1Entity } from './entity';
 import { ITaxonomicUnitV1 } from './entity.schema.types';
 
+const id01 = faker.database.mongodbObjectId().toString();
 const fakeTaxonomicUnit01 = new TaxonomicUnitV1Entity({
-  id: faker.database.mongodbObjectId().toString(),
+  id: id01,
   version: 1,
   name: 'fake-taxonomic-unit-01',
+  lineageIdPath: '/' + id01,
   schema: {
     type: 'object',
     properties: {
@@ -18,10 +20,12 @@ const fakeTaxonomicUnit01 = new TaxonomicUnitV1Entity({
   },
 });
 
+const id02 = faker.database.mongodbObjectId().toString();
 const fakeTaxonomicUnit02 = new TaxonomicUnitV1Entity({
-  id: faker.database.mongodbObjectId().toString(),
+  id: id02,
   version: 2,
   name: 'fake-taxonomic-unit-02',
+  lineageIdPath: '/' + id01 + '/' + id02,
   schema: {
     type: 'object',
     properties: {
@@ -36,10 +40,12 @@ const fakeTaxonomicUnit02 = new TaxonomicUnitV1Entity({
   },
 });
 
+const id03 = faker.database.mongodbObjectId().toString();
 const fakeTaxonomicUnit03 = new TaxonomicUnitV1Entity({
-  id: faker.database.mongodbObjectId().toString(),
+  id: id03,
   version: 1,
   name: 'fake-taxonomic-unit-03',
+  lineageIdPath: '/' + id03,
   schema: {
     properties: {
       name: {

--- a/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/use-cases/create-first-version/index.spec.ts
+++ b/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/use-cases/create-first-version/index.spec.ts
@@ -1,4 +1,4 @@
-import { mongoDbIdFormat } from '@peerlab/kernel/shared-ts-utils/date-formats';
+import { lineageIdPathFormat, mongoDbIdFormat } from '@peerlab/kernel/shared-ts-utils/date-formats';
 import { CreateFirstVersionOfTaxonomicUnitV1UseCase } from '.';
 import { InMemoryTaxonomicUnitsV1Repository } from '../../../adapters/database-repository-in-memory';
 import { TaxonomicUnitsV1DatabaseRepository } from '../../database-repository';
@@ -17,6 +17,7 @@ describe('CreateFirstVersionOfTaxonomicUnitV1UseCase', () => {
   it('should create and persist a valid entity', async () => {
     const createEntityInputDto: ICreateFirstVersionOfTaxonomicUnitV1InputDto = {
       name: 'valid-taxonomic-unit-name',
+      parentId: null,
       schema: {
         properties: {
           parentId: {
@@ -30,6 +31,7 @@ describe('CreateFirstVersionOfTaxonomicUnitV1UseCase', () => {
     const expectedCreatedEntity: ITaxonomicUnitV1 = {
       id: expect.stringMatching(mongoDbIdFormat),
       version: 1,
+      lineageIdPath: expect.stringMatching(lineageIdPathFormat),
       schema: {
         properties: {
           parentId: {
@@ -49,6 +51,7 @@ describe('CreateFirstVersionOfTaxonomicUnitV1UseCase', () => {
     const validName = 'valid-taxonomic-unit-name';
     const createOrganizationInputDto: ICreateFirstVersionOfTaxonomicUnitV1InputDto = {
       name: validName,
+      parentId: null,
       schema: {
         properties: {
           parentId: {
@@ -61,6 +64,7 @@ describe('CreateFirstVersionOfTaxonomicUnitV1UseCase', () => {
 
     const duplicatedNicknameOrganizationInputDto: ICreateFirstVersionOfTaxonomicUnitV1InputDto = {
       name: validName,
+      parentId: null,
       schema: {
         properties: {
           parentId: {

--- a/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/use-cases/create-first-version/index.ts
+++ b/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/use-cases/create-first-version/index.ts
@@ -5,14 +5,14 @@ import { TaxonomicUnitsV1DatabaseRepository } from '../../database-repository';
 import { TaxonomicUnitV1Entity } from '../../entity';
 
 import { ITaxonomicUnitV1 } from '../../entity.schema.types';
-import { DuplicatedTaxonomicUnitV1NameError, UniqueTaxonomicUnitV1NameAndVersionError } from '../../errors';
+import { DuplicatedTaxonomicUnitV1NameError, ParentTaxonomicUnitNotFoundError } from '../../errors';
 import schema from './input-dto.schema';
 import { ICreateFirstVersionOfTaxonomicUnitV1InputDto } from './input-dto.schema.types';
 
 export class CreateFirstVersionOfTaxonomicUnitV1UseCase {
-  private taxonomicUnitsV1DatabaseRepository: TaxonomicUnitsV1DatabaseRepository;
-  private entityName = 'TaxonomicUnitV1';
-  private entityTitle = 'Taxonomic Unit';
+  private readonly taxonomicUnitsV1DatabaseRepository: TaxonomicUnitsV1DatabaseRepository;
+  private readonly entityName = 'TaxonomicUnitV1';
+  private readonly entityTitle = 'Taxonomic Unit';
 
   constructor(taxonomicUnitsV1DatabaseRepository: TaxonomicUnitsV1DatabaseRepository) {
     this.taxonomicUnitsV1DatabaseRepository = taxonomicUnitsV1DatabaseRepository;
@@ -30,7 +30,7 @@ export class CreateFirstVersionOfTaxonomicUnitV1UseCase {
       log.steps.push({ message: 'Validate input dto' });
       schemaValidator.validateOrReject(schema, inputDto);
 
-      log.steps.push({ message: 'Find one by name by name', metadata: { name: inputDto.name } });
+      log.steps.push({ message: 'Find one by name', metadata: { name: inputDto.name } });
       const entityDtoList = await this.taxonomicUnitsV1DatabaseRepository.findManyByName(inputDto.name);
       if (entityDtoList.length > 0) {
         throw new DuplicatedTaxonomicUnitV1NameError(
@@ -39,11 +39,27 @@ export class CreateFirstVersionOfTaxonomicUnitV1UseCase {
       }
 
       log.steps.push({ message: 'Create entity' });
+      const newId = this.taxonomicUnitsV1DatabaseRepository.generateUniqueId();
+      let lineageIdPath = `/${newId}`;
+
+      if (inputDto.parentId) {
+        const parentEntityDto = await this.taxonomicUnitsV1DatabaseRepository.findById(inputDto.parentId);
+
+        if (!parentEntityDto) {
+          throw new ParentTaxonomicUnitNotFoundError(
+            `Parent taxonomic unit with id '${inputDto.parentId}' was not found`,
+          );
+        }
+
+        lineageIdPath = parentEntityDto.lineageIdPath + '/' + newId;
+      }
+
       const newEntity = new TaxonomicUnitV1Entity({
-        id: this.taxonomicUnitsV1DatabaseRepository.generateUniqueId(),
+        id: newId,
         name: inputDto.name,
         schema: inputDto.schema,
         version: 1,
+        lineageIdPath: lineageIdPath,
       });
 
       log.steps.push({ message: 'Save first version in entity repository' });
@@ -52,12 +68,10 @@ export class CreateFirstVersionOfTaxonomicUnitV1UseCase {
       winstonLogger.info(`${this.entityName} created`, log);
       return entityDto;
     } catch (error) {
-      if (error instanceof UniqueTaxonomicUnitV1NameAndVersionError) {
-        log.steps.push({
-          message: error.message,
-          metadata: { stack: error.stack, errorName: 'UniqueTaxonomicUnitV1NameAndVersionError' },
-        });
-      }
+      log.steps.push({
+        message: error.message,
+        metadata: { stack: error.stack },
+      });
 
       winstonLogger.error(`Error creating ${this.entityName}`, log);
       throw error;

--- a/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/use-cases/create-first-version/input-dto.schema.ts
+++ b/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/use-cases/create-first-version/input-dto.schema.ts
@@ -8,8 +8,19 @@ const createFirstVersionOfTaxonomicUnitV1JsonSchema = {
   properties: {
     name: entityDtoSchema.properties.name,
     schema: entityDtoSchema.properties.schema,
+    parentId: {
+      anyOf: [
+        {
+          type: 'string',
+          pattern: '^[0-9a-fA-F]{24}$',
+        },
+        { type: 'null' },
+      ],
+      description:
+        'The unique identifier of the parent taxonomic unit, as a hexadecimal string of 24 characters. If the value is null, the taxon is the root of a taxonomic hierarchy',
+    },
   },
-  required: ['name', 'schema'],
+  required: ['name', 'schema', 'parentId'],
   additionalProperties: false,
 } as const satisfies JSONSchema;
 

--- a/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/use-cases/create-first-version/input-dto.schema.types.d.ts
+++ b/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/use-cases/create-first-version/input-dto.schema.types.d.ts
@@ -17,6 +17,10 @@ export type StringArray = [string, ...string[]];
 export interface ICreateFirstVersionOfTaxonomicUnitV1InputDto {
   name: string;
   schema: HttpJsonSchemaOrgDraft04Schema;
+  /**
+   * The unique identifier of the parent taxonomic unit, as a hexadecimal string of 24 characters. If the value is null, the taxon is the root of a taxonomic hierarchy
+   */
+  parentId: string | null;
 }
 /**
  * Core schema meta-schema

--- a/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/use-cases/get-by-id/index.spec.ts
+++ b/apps/kernel/taxonomic-units/base/src/domains/taxonomic-unit-v1/core/use-cases/get-by-id/index.spec.ts
@@ -17,6 +17,7 @@ describe('GetTaxonomicUnitV1ByIdUseCase', () => {
     const expectedEntityDto = await taxonomicUnitsV1DatabaseRepository.create({
       id: newEntityId,
       version: 1,
+      lineageIdPath: `/${newEntityId}`,
       schema: {
         properties: {
           parentId: {

--- a/apps/kernel/taxonomic-units/rest-api/src/routes/api/v1/taxonomic-units/-/instances/index.ts
+++ b/apps/kernel/taxonomic-units/rest-api/src/routes/api/v1/taxonomic-units/-/instances/index.ts
@@ -37,7 +37,7 @@ export class V1TaxonomicUnitInstancesController {
       log.message = `Success creating entity of schema name ${entityDto.schema.name}`;
       await RestExpressTaxonomicUnitInstanceV1ResponseHandler.handleCreateSuccess(entityDto, res, log);
     } catch (error) {
-      await RestExpressTaxonomicUnitV1ResponseHandler.handleNotFoundError(error, res, log);
+      await RestExpressTaxonomicUnitV1ResponseHandler.handleErrors(error, res, log);
       await RestExpressSharedResponseHandler.handleClientValidationError(error, res, log);
       await RestExpressSharedResponseHandler.handleServerError(error, res, log);
     }

--- a/apps/kernel/taxonomic-units/rest-api/src/routes/api/v1/taxonomic-units/-/instances/post.spec.ts
+++ b/apps/kernel/taxonomic-units/rest-api/src/routes/api/v1/taxonomic-units/-/instances/post.spec.ts
@@ -139,6 +139,9 @@ describe('POST /api/v1/taxonomic-units/-/instances', () => {
             schema: { name: requestBody.schema.name, version: requestBody.schema.version },
             data: { parentId: requestBody.data.parentId },
           });
+        })
+        .catch((error) => {
+          throw error;
         });
     },
   );

--- a/apps/kernel/taxonomic-units/rest-api/src/routes/api/v1/taxonomic-units/[id]/index.ts
+++ b/apps/kernel/taxonomic-units/rest-api/src/routes/api/v1/taxonomic-units/[id]/index.ts
@@ -32,7 +32,7 @@ export class V1TaxonomicUnitByIdController {
       log.message = `Success getting entity by id ${req.params.id}`;
       await RestExpressTaxonomicUnitV1ResponseHandler.handleGetByIdSuccess(entityDto, res, log);
     } catch (error) {
-      await RestExpressTaxonomicUnitV1ResponseHandler.handleNotFoundError(error, res, log);
+      await RestExpressTaxonomicUnitV1ResponseHandler.handleErrors(error, res, log);
       await RestExpressSharedResponseHandler.handleClientValidationError(error, res, log);
       await RestExpressSharedResponseHandler.handleServerError(error, res, log);
     }

--- a/apps/kernel/taxonomic-units/rest-api/src/routes/api/v1/taxonomic-units/get.docs.schema.types.d.ts
+++ b/apps/kernel/taxonomic-units/rest-api/src/routes/api/v1/taxonomic-units/get.docs.schema.types.d.ts
@@ -25,6 +25,10 @@ export interface ITaxonomicUnitV1 {
   id: string;
   version: number;
   name: string;
+  /**
+   * The taxonomic lineage of a taxon (taxonomic unit) from the root to the taxon itself, as represented by a path of ids in the hierarchy
+   */
+  lineageIdPath: string;
   schema: HttpJsonSchemaOrgDraft04Schema;
 }
 /**

--- a/apps/kernel/taxonomic-units/rest-api/src/routes/api/v1/taxonomic-units/index.ts
+++ b/apps/kernel/taxonomic-units/rest-api/src/routes/api/v1/taxonomic-units/index.ts
@@ -1,19 +1,15 @@
-import { ValidationExceptionV2Error } from '@peerlab/kernel/shared-ts-utils/errors/validation-exception-v1';
 import { ILogMetadata } from '@peerlab/kernel/shared-ts-utils/logs/application-logger';
 import { winstonLogger } from '@peerlab/kernel/shared-ts-utils/logs/winston-logger';
 import { defaultPaginationV1Dto } from '@peerlab/kernel/shared-ts-utils/pagination-dto';
 import { schemaValidator } from '@peerlab/kernel/shared-ts-utils/validators/json-schema-validator';
 import { ConfigurationManager } from '@peerlab/kernel/taxonomic-units/base/config/configuration-management';
-import {
-  DuplicatedTaxonomicUnitV1NameError,
-  TaxonomicUnitV1NotFoundError,
-} from '@peerlab/kernel/taxonomic-units/base/domains/taxonomic-unit-v1/core/errors';
+import { RestExpressTaxonomicUnitV1ResponseHandler } from '@peerlab/kernel/taxonomic-units/base/domains/taxonomic-unit-v1/adapters/rest-express-error-handler';
 import express from 'express';
 import getOrganizationsV1UrlQueryParamsJsonSchema from './get-request.schema';
 
 export class V1TaxonomicUnitsController {
   configurationManager: ConfigurationManager;
-  private entityName = 'TaxonomicUnitV1';
+  private readonly entityName = 'TaxonomicUnitV1';
 
   constructor(configurationManager: ConfigurationManager) {
     this.configurationManager = configurationManager;
@@ -34,28 +30,11 @@ export class V1TaxonomicUnitsController {
     try {
       log.steps.push({ message: 'Initialize and execute use case' });
       const { createFirstVersionOfTaxonomicUnitV1UseCase } = await this.configurationManager.getUseCases();
-      const organization = await createFirstVersionOfTaxonomicUnitV1UseCase.execute(req.body);
-      winstonLogger.info(`Success creating ${this.entityName}`, log);
-      return res.status(201).json(organization);
+      const entityDto = await createFirstVersionOfTaxonomicUnitV1UseCase.execute(req.body);
+      log.message = `Success creating ${this.entityName}`;
+      RestExpressTaxonomicUnitV1ResponseHandler.handleCreateSuccess(entityDto, res, log);
     } catch (error) {
-      if (error instanceof ValidationExceptionV2Error) {
-        winstonLogger.warn(error.message, log);
-        return res.status(400).json({ message: error.message });
-      }
-
-      if (error instanceof DuplicatedTaxonomicUnitV1NameError) {
-        winstonLogger.warn(error.message, log);
-        return res.status(409).json({ message: error.message });
-      }
-
-      if (error instanceof TaxonomicUnitV1NotFoundError) {
-        winstonLogger.warn(error.message, log);
-        return res.status(404).json({ message: error.message });
-      }
-
-      winstonLogger.error(`Error creating ${this.entityName}`, log);
-      // Information hiding for security reasons. Detailed message can be found in the logs
-      return res.status(500).json({ message: 'Something went wrong' });
+      RestExpressTaxonomicUnitV1ResponseHandler.handleErrors(error, res, log);
     }
   }
 
@@ -72,7 +51,7 @@ export class V1TaxonomicUnitsController {
       schemaValidator.validateOrReject(getOrganizationsV1UrlQueryParamsJsonSchema, req.query);
 
       log.steps.push({ message: 'Initialize and execute use case' });
-      const { filterOrganizationsV1 } = await this.configurationManager.getUseCases();
+      const { filterTaxonomicUnitsV1UseCase } = await this.configurationManager.getUseCases();
 
       const query = {};
       if (req.query.ownerAgentId) {
@@ -87,23 +66,11 @@ export class V1TaxonomicUnitsController {
         pagination.limit = Number(req.query.limit);
       }
 
-      const organizations = await filterOrganizationsV1.execute({ query, pagination });
+      const organizations = await filterTaxonomicUnitsV1UseCase.execute({ query, pagination });
       winstonLogger.info('Success filtering organizations', log);
       return res.status(200).json(organizations);
     } catch (error) {
-      if (error instanceof ValidationExceptionV2Error) {
-        winstonLogger.warn('Validation error filtering organizations', log);
-        return res.status(400).json({ message: error.message });
-      }
-
-      if (error instanceof TaxonomicUnitV1NotFoundError) {
-        winstonLogger.warn(error.message, log);
-        return res.status(404).json({ message: error.message });
-      }
-
-      winstonLogger.error('Error filtering organizations', log);
-      // Information hiding for security reasons. Detailed message can be found in the logs
-      return res.status(500).json({ message: 'Something went wrong' });
+      RestExpressTaxonomicUnitV1ResponseHandler.handleErrors(error, res, log);
     }
   }
 }

--- a/apps/kernel/taxonomic-units/rest-api/src/routes/api/v1/taxonomic-units/post.spec.ts
+++ b/apps/kernel/taxonomic-units/rest-api/src/routes/api/v1/taxonomic-units/post.spec.ts
@@ -1,3 +1,4 @@
+import { faker } from '@faker-js/faker';
 import { mongoDbIdFormat } from '@peerlab/kernel/shared-ts-utils/date-formats';
 import { MongoDbDriver } from '@peerlab/kernel/shared-ts-utils/drivers/mongodb-driver';
 import { MongoDbMemoryServer } from '@peerlab/kernel/shared-ts-utils/drivers/mongodb-memory-server';
@@ -43,6 +44,7 @@ describe('POST /v1/taxonomic-units', () => {
   it('should create an entity using the REST API, responding with 201 HTTP status', async () => {
     const requestBody: ICreateFirstVersionOfTaxonomicUnitV1InputDto = {
       name: 'fake-name',
+      parentId: null,
       schema: {
         type: 'object',
         properties: {
@@ -62,20 +64,23 @@ describe('POST /v1/taxonomic-units', () => {
       .send(requestBody)
       .then((response) => {
         expect(response.status).toEqual(201);
+        expect(response.body.id).toMatch(mongoDbIdFormat);
 
         const expectedResponseBody: ITaxonomicUnitV1 = {
           id: expect.stringMatching(mongoDbIdFormat),
           name: requestBody.name,
           schema: requestBody.schema,
           version: 1,
+          lineageIdPath: `/${response.body.id}`,
         };
         expect(response.body).toEqual(expectedResponseBody);
       });
   });
 
-  it.skip('should not create entity if a version already exists, responding with 409 HTTP status', async () => {
+  it('should not create entity if a version already exists, responding with 409 HTTP status', async () => {
     const requestBody: ICreateFirstVersionOfTaxonomicUnitV1InputDto = {
       name: fakeTaxonomicUnitsV1[0].name,
+      parentId: null,
       schema: {
         type: 'object',
         properties: {
@@ -95,6 +100,32 @@ describe('POST /v1/taxonomic-units', () => {
       .send(requestBody)
       .then((response) => {
         expect(response.status).toEqual(409);
+      });
+  });
+
+  it('should throw a 404 error if parent taxonomic unit does not exist', async () => {
+    const requestBody = {
+      name: 'fake-name',
+      parentId: faker.database.mongodbObjectId().toString(),
+      schema: {
+        type: 'object',
+        properties: {
+          name: {
+            type: 'string',
+          },
+          parentId: {
+            type: 'string',
+          },
+        },
+        required: ['name'],
+      },
+    };
+    await request
+      .post(`/api/v1/taxonomic-units`)
+      .send(requestBody)
+      .then((response) => {
+        expect(response.status).toEqual(404);
+        expect(response.body.message).toEqual(`Parent taxonomic unit with id '${requestBody.parentId}' was not found`);
       });
   });
 


### PR DESCRIPTION
# What and why was modified?

- It is now possible to add hierarchical relationships between taxonomix units.

# How was it modified?

- Using the parentId attribute at the public api level, with a lineagePathId attribute internally.
