### PR TITLE
fix(KAIZEN): upgrade mongodb in memory and adjust imports

### DIFF
--- a/apps/things/assets-catalog/base/src/domains/assets-v1/adapters/database-repository-mongodb.ts
+++ b/apps/things/assets-catalog/base/src/domains/assets-v1/adapters/database-repository-mongodb.ts
@@ -6,7 +6,8 @@ import { IPaginatedEntities } from '@peerlab/kernel/shared-ts-utils/paginated-en
 import { IPaginationV1Dto } from '@peerlab/kernel/shared-ts-utils/pagination-dto';
 import { Replace } from '@peerlab/kernel/shared-ts-utils/types/replace';
 import { Collection, ObjectId } from 'mongodb';
-import { AssetV1Entity, IAssetV1Dto } from '../core/entity';
+import { AssetV1Entity } from '../core/entity';
+import { IAssetV1Dto } from '../core/entity.schema.types';
 import { AssetsV1DatabaseRepository } from '../core/repository-database';
 
 type IAssetV1DtoWithDates = Replace<IAssetV1Dto, { createdAt: Date; updatedAt: Date }>;

--- a/apps/things/assets-catalog/base/src/domains/taxonomic-units-v1/adapters/database-repository-mongodb.ts
+++ b/apps/things/assets-catalog/base/src/domains/taxonomic-units-v1/adapters/database-repository-mongodb.ts
@@ -5,7 +5,8 @@ import { winstonLogger } from '@peerlab/kernel/shared-ts-utils/logs/winston-logg
 import { IPaginatedEntities } from '@peerlab/kernel/shared-ts-utils/paginated-entities';
 import { IPaginationV1Dto } from '@peerlab/kernel/shared-ts-utils/pagination-dto';
 import { Collection, MongoError, ObjectId } from 'mongodb';
-import { ITaxonomicUnitV1Dto, TaxonomicUnitV1Entity } from '../core/entity';
+import { TaxonomicUnitV1Entity } from '../core/entity';
+import { ITaxonomicUnitV1Dto } from '../core/entity.schema.types';
 import { TaxonomicUnitsV1DatabaseRepository } from '../core/repository-database';
 import { TaxonomicUnitAlreadyExistsError } from '../core/use-cases/create-taxonomic-unit/errors';
 

--- a/apps/things/assets-catalog/base/src/domains/taxonomic-units-v1/core/repository-database.ts
+++ b/apps/things/assets-catalog/base/src/domains/taxonomic-units-v1/core/repository-database.ts
@@ -1,7 +1,7 @@
 import { CreateManyResponseDto } from '@peerlab/kernel/shared-ts-utils/create-many-response-dto';
 import { IPaginatedEntities } from '@peerlab/kernel/shared-ts-utils/paginated-entities';
 import { IPaginationV1Dto } from '@peerlab/kernel/shared-ts-utils/pagination-dto';
-import { ITaxonomicUnitV1Dto } from './entity';
+import { ITaxonomicUnitV1Dto } from './entity.schema.types';
 
 export abstract class TaxonomicUnitsV1DatabaseRepository {
   abstract generateUniqueId(): string;

--- a/apps/things/assets-catalog/rest-api/src/routes/api/v1/assets/post.docs.ts
+++ b/apps/things/assets-catalog/rest-api/src/routes/api/v1/assets/post.docs.ts
@@ -1,5 +1,5 @@
-import { assetV1JsonSchema } from '@peerlab/things/assets-catalog/base/domains/assets-v1/core/entity';
-import { createAssetV1InputDtoSchema } from '@peerlab/things/assets-catalog/base/domains/assets-v1/core/use-cases/create-asset';
+import { default as assetV1JsonSchema } from '@peerlab/things/assets-catalog/base/domains/assets-v1/core/entity.schema';
+import { default as createAssetV1InputDtoSchema } from '@peerlab/things/assets-catalog/base/domains/assets-v1/core/use-cases/create-asset/input-dto.schema';
 import { OperationObject } from 'openapi3-ts/oas30';
 
 export const postAssetV1Schema: OperationObject = {

--- a/apps/things/assets-catalog/rest-api/src/routes/api/v1/taxonomic-units/post.docs.ts
+++ b/apps/things/assets-catalog/rest-api/src/routes/api/v1/taxonomic-units/post.docs.ts
@@ -1,5 +1,4 @@
-import { taxonomicUnitV1JsonSchema } from '@peerlab/things/assets-catalog/base/domains/taxonomic-units-v1/core/entity';
-import { createTaxonomicUnitV1InputDtoSchema } from '@peerlab/things/assets-catalog/base/domains/taxonomic-units-v1/core/use-cases/create-taxonomic-unit';
+import { default as createTaxonomicUnitV1InputDtoSchema, default as taxonomicUnitV1JsonSchema } from '@peerlab/kernel/taxonomic-units/base/domains/taxonomic-unit-v1/core/entity.schema';
 import { OperationObject } from 'openapi3-ts/oas30';
 
 export const postTaxonomicUnitV1Schema: OperationObject = {

--- a/apps/things/assets-catalog/rest-api/src/routes/docs/v3/open-api-json/entity.ts
+++ b/apps/things/assets-catalog/rest-api/src/routes/docs/v3/open-api-json/entity.ts
@@ -1,7 +1,8 @@
-import { AssetV1Entity, assetV1JsonSchema } from '@peerlab/things/assets-catalog/base/domains/assets-v1/core/entity';
+import taxonomicUnitV1JsonSchema from '@peerlab/kernel/taxonomic-units/base/domains/taxonomic-unit-v1/core/entity.schema';
+import { AssetV1Entity } from '@peerlab/things/assets-catalog/base/domains/assets-v1/core/entity';
+import assetV1JsonSchema from '@peerlab/things/assets-catalog/base/domains/assets-v1/core/entity.schema';
 import {
   TaxonomicUnitV1Entity,
-  taxonomicUnitV1JsonSchema,
 } from '@peerlab/things/assets-catalog/base/domains/taxonomic-units-v1/core/entity';
 import { OpenApiBuilder } from 'openapi3-ts/oas30';
 import { assetsV1ControllerSchema } from '../../../api/v1/assets/index.docs';

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "people-skill-set-browser:build": "pnpm --filter ./apps/people/skill-set/browser run build",
     "people-skill-set-browser:start": "pnpm --filter ./apps/people/skill-set/browser run start",
-    "prepare": "husky install",
+    "prepare": "husky install && sh setup-after-install.sh",
     "git:discard:all": "git checkout -- .",
     "release": "lerna version --yes --conventional-commits --changelog-preset ./changelog-preset.config.js",
     "release:no-push": "lerna version --yes --conventional-commits --changelog-preset ./changelog-preset.config.js --no-push",
@@ -254,7 +254,7 @@
     "lodash.throttle": "4.1.1",
     "mapbox-gl": "2.15.0",
     "mongodb": "6.4.0",
-    "mongodb-memory-server": "9.1.7",
+    "mongodb-memory-server": "10.1.2",
     "mongoose": "6.11.3",
     "mui-one-time-password-input": "1.1.2",
     "next": "14.2.1",
@@ -309,9 +309,8 @@
     "zod": "3.22.3"
   },
   "volta": {
-    "node": "18.16.0",
-    "npm": "8.19.4",
-    "yarn": "1.22.19",
-    "pnpm": "8.6.7"
+    "node": "22.11.0",
+    "npm": "10.9.0",
+    "pnpm": "9.14.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,19 +118,19 @@ importers:
         version: 10.0.5(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/microservices@10.0.5)(@nestjs/platform-express@10.0.5)(encoding@0.1.13)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/devtools-integration':
         specifier: 0.1.5
-        version: 0.1.5(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/microservices@10.0.5)(@nestjs/platform-express@10.0.5)(encoding@0.1.13)(reflect-metadata@0.1.13)(rxjs@7.8.1))(encoding@0.1.13)(reflect-metadata@0.1.13)
+        version: 0.1.5(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5)(encoding@0.1.13)(reflect-metadata@0.1.13)
       '@nestjs/microservices':
         specifier: 10.0.5
         version: 10.0.5(@grpc/grpc-js@1.11.1)(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5)(kafkajs@2.2.4)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/mongoose':
         specifier: 10.0.0
-        version: 10.0.0(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/microservices@10.0.5)(@nestjs/platform-express@10.0.5)(encoding@0.1.13)(reflect-metadata@0.1.13)(rxjs@7.8.1))(mongoose@6.11.3(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0)))(reflect-metadata@0.1.13)(rxjs@7.8.1)
+        version: 10.0.0(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5)(mongoose@6.11.3(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0)))(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/platform-express':
         specifier: 10.0.5
         version: 10.0.5(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5)
       '@nestjs/swagger':
         specifier: 7.1.1
-        version: 7.1.1(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/microservices@10.0.5)(@nestjs/platform-express@10.0.5)(encoding@0.1.13)(reflect-metadata@0.1.13)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)
+        version: 7.1.1(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5)(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)
       '@nx/nest':
         specifier: 19.0.0
         version: 19.0.0(@babel/traverse@7.25.1)(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(chokidar@3.6.0)(js-yaml@4.1.0)(nx@19.0.0(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3)))(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4))(typescript@5.5.4)
@@ -169,7 +169,7 @@ importers:
         version: 5.19.4(@rjsf/utils@5.19.4(react@18.3.1))
       '@scalar/express-api-reference':
         specifier: ^0.4.45
-        version: 0.4.120(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(postcss@8.4.39)(storybook@7.6.20(encoding@0.1.13))(tailwindcss@3.3.3(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))
+        version: 0.4.120(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(postcss@8.4.39)(storybook@7.6.20(encoding@0.1.13))(tailwindcss@3.3.3(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(typescript@5.5.4)(vitest@1.6.0)
       '@swc/helpers':
         specifier: 0.5.3
         version: 0.5.3
@@ -300,8 +300,8 @@ importers:
         specifier: 6.4.0
         version: 6.4.0(@aws-sdk/credential-providers@3.620.0(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0)))(socks@2.8.3)
       mongodb-memory-server:
-        specifier: 9.1.7
-        version: 9.1.7(@aws-sdk/credential-providers@3.620.0(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0)))
+        specifier: 10.1.2
+        version: 10.1.2(@aws-sdk/credential-providers@3.620.0(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0)))(socks@2.8.3)
       mongoose:
         specifier: 6.11.3
         version: 6.11.3(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0))
@@ -479,7 +479,7 @@ importers:
         version: 10.0.1(chokidar@3.6.0)(typescript@5.5.4)
       '@nestjs/testing':
         specifier: 10.2.6
-        version: 10.2.6(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/microservices@10.0.5)(@nestjs/platform-express@10.0.5)(encoding@0.1.13)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/microservices@10.0.5(@grpc/grpc-js@1.11.1)(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5)(kafkajs@2.2.4)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/platform-express@10.0.5(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5))
+        version: 10.2.6(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5)(@nestjs/microservices@10.0.5)(@nestjs/platform-express@10.0.5)
       '@nx/cypress':
         specifier: 19.0.0
         version: 19.0.0(@babel/traverse@7.25.1)(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(cypress@13.13.1)(js-yaml@4.1.0)(nx@19.0.0(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3)))(typescript@5.5.4)
@@ -518,7 +518,7 @@ importers:
         version: 19.0.0(@babel/traverse@7.25.1)(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(cypress@13.13.1)(js-yaml@4.1.0)(nx@19.0.0(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3)))(typescript@5.5.4)
       '@nx/vite':
         specifier: 19.0.0
-        version: 19.0.0(@babel/traverse@7.25.1)(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(nx@19.0.0(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3)))(typescript@5.5.4)(vite@5.2.8(@types/node@18.19.31)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))
+        version: 19.0.0(@babel/traverse@7.25.1)(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(nx@19.0.0(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3)))(typescript@5.5.4)(vite@5.2.8(@types/node@18.19.31)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))(vitest@1.6.0)
       '@nx/web':
         specifier: 19.0.0
         version: 19.0.0(@babel/traverse@7.25.1)(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(nx@19.0.0(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3)))(typescript@5.5.4)
@@ -542,7 +542,7 @@ importers:
         version: 7.6.20(encoding@0.1.13)
       '@storybook/jest':
         specifier: ^0.2.3
-        version: 0.2.3(@jest/globals@29.7.0)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))
+        version: 0.2.3(@jest/globals@29.7.0)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(vitest@1.6.0)
       '@storybook/react':
         specifier: 7.6.20
         version: 7.6.20(encoding@0.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
@@ -575,7 +575,7 @@ importers:
         version: 2.5.124
       '@testing-library/jest-dom':
         specifier: 6.1.3
-        version: 6.1.3(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))
+        version: 6.1.3(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(vitest@1.6.0)
       '@testing-library/react':
         specifier: 15.0.6
         version: 15.0.6(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -662,10 +662,10 @@ importers:
         version: 3.6.0(@swc/helpers@0.5.3)(vite@5.2.8(@types/node@18.19.31)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))
       '@vitest/coverage-c8':
         specifier: 0.32.0
-        version: 0.32.0(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))
+        version: 0.32.0(vitest@1.6.0)
       '@vitest/coverage-v8':
         specifier: 1.6.0
-        version: 1.6.0(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))
+        version: 1.6.0(vitest@1.6.0)
       '@vitest/ui':
         specifier: 1.6.0
         version: 1.6.0(vitest@1.6.0)
@@ -3937,6 +3937,9 @@ packages:
 
   '@mongodb-js/saslprep@1.1.8':
     resolution: {integrity: sha512-qKwC/M/nNNaKUBMQ0nuzm47b7ZYWQHN3pcXq4IIcoSBc2hOIrflAxJduIvvqmhoz3gR2TacTAs8vlsCVPkiEdQ==}
+
+  '@mongodb-js/saslprep@1.1.9':
+    resolution: {integrity: sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==}
 
   '@mui/base@5.0.0-beta.6':
     resolution: {integrity: sha512-jcHy6HwOX7KzRhRtL8nvIvUlxvLx2Fl6NMRCyUSQSvMTyfou9kndekz0H4HJaXvG1Y4WEifk23RYedOlrD1kEQ==}
@@ -8214,8 +8217,8 @@ packages:
   async-limiter@1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
 
-  async-mutex@0.4.1:
-    resolution: {integrity: sha512-WfoBo4E/TbCX1G95XTjbWTE3X2XLG0m1Xbv2cwOtuPdyH9CZvnaA5nCt1ucjaKEgW2A5IF71hxrRhr83Je5xjA==}
+  async-mutex@0.5.0:
+    resolution: {integrity: sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==}
 
   async-retry@1.3.3:
     resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
@@ -8547,9 +8550,9 @@ packages:
     resolution: {integrity: sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==}
     engines: {node: '>=6.9.0'}
 
-  bson@5.5.1:
-    resolution: {integrity: sha512-ix0EwukN2EpC0SRWIj/7B5+A6uQMQy6KMREI9qQqvgpkV2frH63T0UDVd1SYedL6dNCmDBYB3QtXi4ISk9YT+g==}
-    engines: {node: '>=14.20.1'}
+  bson@6.10.0:
+    resolution: {integrity: sha512-ROchNosXMJD2cbQGm84KoP7vOGPO6/bOAW0veMMbzhXLqoZptcaYRVLitwvuhwhjjpU1qP4YZRWLhgETdgqUQw==}
+    engines: {node: '>=16.20.1'}
 
   bson@6.8.0:
     resolution: {integrity: sha512-iOJg8pr7wq2tg/zSlCCHMi3hMm5JTOxLTagf3zxhcenHsFp+c6uOs6K7W5UE7A4QIJGtqh/ZovFNMP4mOPJynQ==}
@@ -9829,6 +9832,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.3.7:
+    resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decamelize-keys@1.1.1:
     resolution: {integrity: sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==}
     engines: {node: '>=0.10.0'}
@@ -10494,6 +10506,7 @@ packages:
   eslint@8.57.0:
     resolution: {integrity: sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   esniff@2.0.1:
@@ -10932,6 +10945,15 @@ packages:
 
   follow-redirects@1.15.6:
     resolution: {integrity: sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
+  follow-redirects@1.15.9:
+    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -14025,37 +14047,43 @@ packages:
   mongodb-connection-string-url@3.0.1:
     resolution: {integrity: sha512-XqMGwRX0Lgn05TDB4PyG2h2kKO/FfWJyCzYQbIhXUxz7ETt0I/FqHjUeqj37irJ+Dl1ZtU82uYyj14u2XsZKfg==}
 
-  mongodb-memory-server-core@9.1.7:
-    resolution: {integrity: sha512-q8geqCmt5hGuxaDhRo03ZUB0ITr6lnJ3jffdNiC4nDq13WbHUfY2A1RQq3OHDbdrY6aRYvZphx2bcXYBFRis3A==}
-    engines: {node: '>=14.20.1'}
+  mongodb-memory-server-core@10.1.2:
+    resolution: {integrity: sha512-5Wpz712CuDCKTn/40UZ+kMZlav4Y2imbpWuJU5wjuZk6s3+Jg8akTIBW9jQiFS8wgymu6iTg99Iw0XcypsLyQA==}
+    engines: {node: '>=16.20.1'}
 
-  mongodb-memory-server@9.1.7:
-    resolution: {integrity: sha512-Yxw1cUMoCKTK6jxk4cKG07P+Z/qOmuCVyt3ScIDaoHeOCbOlg2sEtXYO9vEK/tzpj/1KHdDStU2oYrsJ8Fvm0A==}
-    engines: {node: '>=14.20.1'}
+  mongodb-memory-server@10.1.2:
+    resolution: {integrity: sha512-aDGEWuUVHTiBvaaq03LbpvvSk8IVtepbvp314p1cq7f2xdSpl7igMnYpPfYY5nkks1I5I6OL2ypHjaJj4kBp+g==}
+    engines: {node: '>=16.20.1'}
 
   mongodb@4.16.0:
     resolution: {integrity: sha512-0EB113Fsucaq1wsY0dOhi1fmZOwFtLOtteQkiqOXGklvWMnSH3g2QS53f0KTP+/6qOkuoXE2JksubSZNmxeI+g==}
     engines: {node: '>=12.9.0'}
 
-  mongodb@5.9.2:
-    resolution: {integrity: sha512-H60HecKO4Bc+7dhOv4sJlgvenK4fQNqqUIlXxZYQNbfEWSALGAwGoyJd/0Qwk4TttFXUOHJ2ZJQe/52ScaUwtQ==}
-    engines: {node: '>=14.20.1'}
+  mongodb@6.11.0:
+    resolution: {integrity: sha512-yVbPw0qT268YKhG241vAMLaDQAPbRyTgo++odSgGc9kXnzOujQI60Iyj23B9sQQFPSvmNPvMZ3dsFz0aN55KgA==}
+    engines: {node: '>=16.20.1'}
     peerDependencies:
       '@aws-sdk/credential-providers': ^3.188.0
-      '@mongodb-js/zstd': ^1.0.0
-      kerberos: ^1.0.0 || ^2.0.0
-      mongodb-client-encryption: '>=2.3.0 <3'
+      '@mongodb-js/zstd': ^1.1.0
+      gcp-metadata: ^5.2.0
+      kerberos: ^2.0.1
+      mongodb-client-encryption: '>=6.0.0 <7'
       snappy: ^7.2.2
+      socks: ^2.7.1
     peerDependenciesMeta:
       '@aws-sdk/credential-providers':
         optional: true
       '@mongodb-js/zstd':
+        optional: true
+      gcp-metadata:
         optional: true
       kerberos:
         optional: true
       mongodb-client-encryption:
         optional: true
       snappy:
+        optional: true
+      socks:
         optional: true
 
   mongodb@6.4.0:
@@ -15783,6 +15811,7 @@ packages:
 
   react-beautiful-dnd@13.1.1:
     resolution: {integrity: sha512-0Lvs4tq2VcrEjEgDXHjT98r+63drkKEgqyxdA7qD3mvKwga6a5SscbdLPO2IExotU1jW8L0Ksdl0Cj2AF67nPQ==}
+    deprecated: 'react-beautiful-dnd is now deprecated. Context and options: https://github.com/atlassian/react-beautiful-dnd/issues/2672'
     peerDependencies:
       react: ^16.8.5 || ^17.0.0 || ^18.0.0
       react-dom: ^16.8.5 || ^17.0.0 || ^18.0.0
@@ -17762,6 +17791,9 @@ packages:
   tslib@2.6.3:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   tss-react@4.8.8:
     resolution: {integrity: sha512-V57AU6J42LLhYhRGSxDVi9VLUaoQtV6y2Kb1e0uqabe3w61G9R8gkUiX4DHZUReboRY9rwExPWz0LVZIgqQ98Q==}
     peerDependencies:
@@ -18873,6 +18905,10 @@ packages:
 
   yauzl@2.10.0:
     resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
+  yauzl@3.2.0:
+    resolution: {integrity: sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==}
+    engines: {node: '>=12'}
 
   yjs@13.6.18:
     resolution: {integrity: sha512-GBTjO4QCmv2HFKFkYIJl7U77hIB1o22vSCSQD1Ge8ZxWbIbn8AltI4gyXbtL+g5/GJep67HCMq3Y5AmNwDSyEg==}
@@ -22672,7 +22708,7 @@ snapshots:
       '@types/node': 20.5.1
       chalk: 4.1.2
       cosmiconfig: 8.3.6(typescript@5.5.4)
-      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.5.4))(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@20.5.1)(typescript@5.5.4))(typescript@5.5.4)
+      cosmiconfig-typescript-loader: 4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.5.4))(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4))(typescript@5.5.4)
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
@@ -25518,6 +25554,10 @@ snapshots:
     dependencies:
       sparse-bitfield: 3.0.3
 
+  '@mongodb-js/saslprep@1.1.9':
+    dependencies:
+      sparse-bitfield: 3.0.3
+
   '@mui/base@5.0.0-beta.6(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.0
@@ -25764,7 +25804,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@nestjs/devtools-integration@0.1.5(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/microservices@10.0.5)(@nestjs/platform-express@10.0.5)(encoding@0.1.13)(reflect-metadata@0.1.13)(rxjs@7.8.1))(encoding@0.1.13)(reflect-metadata@0.1.13)':
+  '@nestjs/devtools-integration@0.1.5(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5)(encoding@0.1.13)(reflect-metadata@0.1.13)':
     dependencies:
       '@nestjs/common': 10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/core': 10.0.5(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/microservices@10.0.5)(@nestjs/platform-express@10.0.5)(encoding@0.1.13)(reflect-metadata@0.1.13)(rxjs@7.8.1)
@@ -25794,7 +25834,7 @@ snapshots:
       '@grpc/grpc-js': 1.11.1
       kafkajs: 2.2.4
 
-  '@nestjs/mongoose@10.0.0(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/microservices@10.0.5)(@nestjs/platform-express@10.0.5)(encoding@0.1.13)(reflect-metadata@0.1.13)(rxjs@7.8.1))(mongoose@6.11.3(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0)))(reflect-metadata@0.1.13)(rxjs@7.8.1)':
+  '@nestjs/mongoose@10.0.0(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5)(mongoose@6.11.3(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0)))(reflect-metadata@0.1.13)(rxjs@7.8.1)':
     dependencies:
       '@nestjs/common': 10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/core': 10.0.5(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/microservices@10.0.5)(@nestjs/platform-express@10.0.5)(encoding@0.1.13)(reflect-metadata@0.1.13)(rxjs@7.8.1)
@@ -25835,7 +25875,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@nestjs/swagger@7.1.1(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/microservices@10.0.5)(@nestjs/platform-express@10.0.5)(encoding@0.1.13)(reflect-metadata@0.1.13)(rxjs@7.8.1))(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)':
+  '@nestjs/swagger@7.1.1(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5)(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)':
     dependencies:
       '@nestjs/common': 10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/core': 10.0.5(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/microservices@10.0.5)(@nestjs/platform-express@10.0.5)(encoding@0.1.13)(reflect-metadata@0.1.13)(rxjs@7.8.1)
@@ -25849,7 +25889,7 @@ snapshots:
       class-transformer: 0.5.1
       class-validator: 0.14.0
 
-  '@nestjs/testing@10.2.6(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/microservices@10.0.5)(@nestjs/platform-express@10.0.5)(encoding@0.1.13)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/microservices@10.0.5(@grpc/grpc-js@1.11.1)(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5)(kafkajs@2.2.4)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/platform-express@10.0.5(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5))':
+  '@nestjs/testing@10.2.6(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/core@10.0.5)(@nestjs/microservices@10.0.5)(@nestjs/platform-express@10.0.5)':
     dependencies:
       '@nestjs/common': 10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/core': 10.0.5(@nestjs/common@10.2.6(class-transformer@0.5.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1))(@nestjs/microservices@10.0.5)(@nestjs/platform-express@10.0.5)(encoding@0.1.13)(reflect-metadata@0.1.13)(rxjs@7.8.1)
@@ -26275,9 +26315,9 @@ snapshots:
       - '@swc/core'
       - debug
 
-  '@nrwl/vite@19.0.0(@babel/traverse@7.25.1)(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(nx@19.0.0(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3)))(typescript@5.5.4)(vite@5.2.8(@types/node@18.19.31)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))':
+  '@nrwl/vite@19.0.0(@babel/traverse@7.25.1)(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(nx@19.0.0(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3)))(typescript@5.5.4)(vite@5.2.8(@types/node@18.19.31)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))(vitest@1.6.0)':
     dependencies:
-      '@nx/vite': 19.0.0(@babel/traverse@7.25.1)(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(nx@19.0.0(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3)))(typescript@5.5.4)(vite@5.2.8(@types/node@18.19.31)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))
+      '@nx/vite': 19.0.0(@babel/traverse@7.25.1)(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(nx@19.0.0(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3)))(typescript@5.5.4)(vite@5.2.8(@types/node@18.19.31)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))(vitest@1.6.0)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc-node/register'
@@ -26846,9 +26886,9 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vite@19.0.0(@babel/traverse@7.25.1)(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(nx@19.0.0(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3)))(typescript@5.5.4)(vite@5.2.8(@types/node@18.19.31)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))':
+  '@nx/vite@19.0.0(@babel/traverse@7.25.1)(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(nx@19.0.0(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3)))(typescript@5.5.4)(vite@5.2.8(@types/node@18.19.31)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))(vitest@1.6.0)':
     dependencies:
-      '@nrwl/vite': 19.0.0(@babel/traverse@7.25.1)(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(nx@19.0.0(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3)))(typescript@5.5.4)(vite@5.2.8(@types/node@18.19.31)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))
+      '@nrwl/vite': 19.0.0(@babel/traverse@7.25.1)(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(nx@19.0.0(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3)))(typescript@5.5.4)(vite@5.2.8(@types/node@18.19.31)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))(vitest@1.6.0)
       '@nx/devkit': 19.0.0(nx@19.0.0(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3)))
       '@nx/js': 19.0.0(@babel/traverse@7.25.1)(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(nx@19.0.0(@swc-node/register@1.8.0(@swc/core@1.3.85(@swc/helpers@0.5.3))(@swc/types@0.1.12)(typescript@5.5.4))(@swc/core@1.3.85(@swc/helpers@0.5.3)))(typescript@5.5.4)
       '@phenomnomnominal/tsquery': 5.0.1(typescript@5.5.4)
@@ -28286,11 +28326,11 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@scalar/api-client@2.0.34(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(storybook@7.6.20(encoding@0.1.13))(tailwindcss@3.3.3(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))':
+  '@scalar/api-client@2.0.34(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(storybook@7.6.20(encoding@0.1.13))(tailwindcss@3.3.3(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(typescript@5.5.4)(vitest@1.6.0)':
     dependencies:
       '@headlessui/tailwindcss': 0.2.1(tailwindcss@3.3.3(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))
       '@headlessui/vue': 1.7.22(vue@3.4.34(typescript@5.5.4))
-      '@scalar/components': 0.12.21(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(storybook@7.6.20(encoding@0.1.13))(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))
+      '@scalar/components': 0.12.21(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(storybook@7.6.20(encoding@0.1.13))(typescript@5.5.4)(vitest@1.6.0)
       '@scalar/draggable': 0.1.3(typescript@5.5.4)
       '@scalar/oas-utils': 0.2.18(typescript@5.5.4)
       '@scalar/object-utils': 1.1.5(vue@3.4.34(typescript@5.5.4))
@@ -28323,12 +28363,12 @@ snapshots:
       - typescript
       - vitest
 
-  '@scalar/api-reference@1.24.59(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(postcss@8.4.39)(storybook@7.6.20(encoding@0.1.13))(tailwindcss@3.3.3(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))':
+  '@scalar/api-reference@1.24.59(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(postcss@8.4.39)(storybook@7.6.20(encoding@0.1.13))(tailwindcss@3.3.3(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(typescript@5.5.4)(vitest@1.6.0)':
     dependencies:
       '@floating-ui/vue': 1.1.2(vue@3.4.34(typescript@5.5.4))
       '@headlessui/vue': 1.7.22(vue@3.4.34(typescript@5.5.4))
-      '@scalar/api-client': 2.0.34(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(storybook@7.6.20(encoding@0.1.13))(tailwindcss@3.3.3(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))
-      '@scalar/components': 0.12.21(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(storybook@7.6.20(encoding@0.1.13))(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))
+      '@scalar/api-client': 2.0.34(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(storybook@7.6.20(encoding@0.1.13))(tailwindcss@3.3.3(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(typescript@5.5.4)(vitest@1.6.0)
+      '@scalar/components': 0.12.21(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(storybook@7.6.20(encoding@0.1.13))(typescript@5.5.4)(vitest@1.6.0)
       '@scalar/oas-utils': 0.2.18(typescript@5.5.4)
       '@scalar/openapi-parser': 0.7.2
       '@scalar/snippetz': 0.1.6
@@ -28382,13 +28422,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@scalar/components@0.12.21(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(storybook@7.6.20(encoding@0.1.13))(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))':
+  '@scalar/components@0.12.21(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(storybook@7.6.20(encoding@0.1.13))(typescript@5.5.4)(vitest@1.6.0)':
     dependencies:
       '@floating-ui/utils': 0.2.5
       '@floating-ui/vue': 1.1.2(vue@3.4.34(typescript@5.5.4))
       '@headlessui/vue': 1.7.22(vue@3.4.34(typescript@5.5.4))
       '@scalar/code-highlight': 0.0.7
-      '@storybook/test': 8.2.6(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(storybook@7.6.20(encoding@0.1.13))(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))
+      '@storybook/test': 8.2.6(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(storybook@7.6.20(encoding@0.1.13))(vitest@1.6.0)
       '@vueuse/core': 10.11.0(vue@3.4.34(typescript@5.5.4))
       cva: 1.0.0-beta.1(typescript@5.5.4)
       nanoid: 5.0.7
@@ -28412,9 +28452,9 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@scalar/express-api-reference@0.4.120(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(postcss@8.4.39)(storybook@7.6.20(encoding@0.1.13))(tailwindcss@3.3.3(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))':
+  '@scalar/express-api-reference@0.4.120(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(postcss@8.4.39)(storybook@7.6.20(encoding@0.1.13))(tailwindcss@3.3.3(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(typescript@5.5.4)(vitest@1.6.0)':
     dependencies:
-      '@scalar/api-reference': 1.24.59(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(postcss@8.4.39)(storybook@7.6.20(encoding@0.1.13))(tailwindcss@3.3.3(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(typescript@5.5.4)(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))
+      '@scalar/api-reference': 1.24.59(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(postcss@8.4.39)(storybook@7.6.20(encoding@0.1.13))(tailwindcss@3.3.3(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(typescript@5.5.4)(vitest@1.6.0)
       express: 4.19.2
     transitivePeerDependencies:
       - '@jest/globals'
@@ -29409,10 +29449,10 @@ snapshots:
       storybook: 7.6.20(encoding@0.1.13)
       util: 0.12.5
 
-  '@storybook/jest@0.2.3(@jest/globals@29.7.0)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))':
+  '@storybook/jest@0.2.3(@jest/globals@29.7.0)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(vitest@1.6.0)':
     dependencies:
       '@storybook/expect': 28.1.3-5
-      '@testing-library/jest-dom': 6.1.3(@jest/globals@29.7.0)(@types/jest@28.1.3)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))
+      '@testing-library/jest-dom': 6.1.3(@jest/globals@29.7.0)(@types/jest@28.1.3)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(vitest@1.6.0)
       '@types/jest': 28.1.3
       jest-mock: 27.5.1
     transitivePeerDependencies:
@@ -29581,12 +29621,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@storybook/test@8.2.6(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(storybook@7.6.20(encoding@0.1.13))(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))':
+  '@storybook/test@8.2.6(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(storybook@7.6.20(encoding@0.1.13))(vitest@1.6.0)':
     dependencies:
       '@storybook/csf': 0.1.11
       '@storybook/instrumenter': 8.2.6(storybook@7.6.20(encoding@0.1.13))
       '@testing-library/dom': 10.1.0
-      '@testing-library/jest-dom': 6.4.5(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))
+      '@testing-library/jest-dom': 6.4.5(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(vitest@1.6.0)
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.1.0)
       '@vitest/expect': 1.6.0
       '@vitest/spy': 1.6.0
@@ -30028,7 +30068,7 @@ snapshots:
       lz-string: 1.5.0
       pretty-format: 27.5.1
 
-  '@testing-library/jest-dom@6.1.3(@jest/globals@29.7.0)(@types/jest@28.1.3)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))':
+  '@testing-library/jest-dom@6.1.3(@jest/globals@29.7.0)(@types/jest@28.1.3)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(vitest@1.6.0)':
     dependencies:
       '@adobe/css-tools': 4.4.0
       '@babel/runtime': 7.25.0
@@ -30044,7 +30084,7 @@ snapshots:
       jest: 29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4))
       vitest: 1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3)
 
-  '@testing-library/jest-dom@6.1.3(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))':
+  '@testing-library/jest-dom@6.1.3(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(vitest@1.6.0)':
     dependencies:
       '@adobe/css-tools': 4.4.0
       '@babel/runtime': 7.25.0
@@ -30060,7 +30100,7 @@ snapshots:
       jest: 29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4))
       vitest: 1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3)
 
-  '@testing-library/jest-dom@6.4.5(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))':
+  '@testing-library/jest-dom@6.4.5(@jest/globals@29.7.0)(@types/jest@29.4.4)(jest@29.4.3(@types/node@18.19.31)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)))(vitest@1.6.0)':
     dependencies:
       '@adobe/css-tools': 4.4.0
       '@babel/runtime': 7.25.0
@@ -31023,7 +31063,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-c8@0.32.0(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))':
+  '@vitest/coverage-c8@0.32.0(vitest@1.6.0)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       c8: 7.14.0
@@ -31032,7 +31072,7 @@ snapshots:
       std-env: 3.7.0
       vitest: 1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3)
 
-  '@vitest/coverage-v8@1.6.0(vitest@1.6.0(@types/node@18.19.31)(@vitest/ui@1.6.0)(jsdom@22.1.0)(less@4.1.3)(sass@1.77.8)(stylus@0.59.0)(terser@5.31.3))':
+  '@vitest/coverage-v8@1.6.0(vitest@1.6.0)':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -31364,7 +31404,7 @@ snapshots:
 
   agent-base@7.1.1:
     dependencies:
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -31672,9 +31712,9 @@ snapshots:
 
   async-limiter@1.0.1: {}
 
-  async-mutex@0.4.1:
+  async-mutex@0.5.0:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   async-retry@1.3.3:
     dependencies:
@@ -32163,7 +32203,7 @@ snapshots:
     dependencies:
       buffer: 5.7.1
 
-  bson@5.5.1: {}
+  bson@6.10.0: {}
 
   bson@6.8.0: {}
 
@@ -32922,11 +32962,11 @@ snapshots:
     dependencies:
       layout-base: 2.0.1
 
-  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.5.4))(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@20.5.1)(typescript@5.5.4))(typescript@5.5.4):
+  cosmiconfig-typescript-loader@4.4.0(@types/node@20.5.1)(cosmiconfig@8.3.6(typescript@5.5.4))(ts-node@10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4))(typescript@5.5.4):
     dependencies:
       '@types/node': 20.5.1
       cosmiconfig: 8.3.6(typescript@5.5.4)
-      ts-node: 10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@20.5.1)(typescript@5.5.4)
+      ts-node: 10.9.1(@swc/core@1.3.85(@swc/helpers@0.5.3))(@types/node@18.19.31)(typescript@5.5.4)
       typescript: 5.5.4
 
   cosmiconfig@5.2.1:
@@ -33682,6 +33722,10 @@ snapshots:
     optionalDependencies:
       supports-color: 8.1.1
 
+  debug@4.3.7:
+    dependencies:
+      ms: 2.1.3
+
   decamelize-keys@1.1.1:
     dependencies:
       decamelize: 1.2.0
@@ -34382,8 +34426,8 @@ snapshots:
       debug: 4.3.6(supports-color@8.1.1)
       enhanced-resolve: 5.17.1
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.27.5)(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@7.9.0(eslint@8.57.0)(typescript@5.5.4))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.6
       is-core-module: 2.15.0
@@ -34394,7 +34438,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.27.5)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7(supports-color@8.1.1)
     optionalDependencies:
@@ -34429,7 +34473,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.27.5)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@5.5.4))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
       has: 1.0.4
       is-core-module: 2.15.0
       is-glob: 4.0.3
@@ -35234,6 +35278,10 @@ snapshots:
   follow-redirects@1.15.6(debug@4.3.6):
     optionalDependencies:
       debug: 4.3.6(supports-color@8.1.1)
+
+  follow-redirects@1.15.9(debug@4.3.7):
+    optionalDependencies:
+      debug: 4.3.7
 
   fontkit@2.0.2:
     dependencies:
@@ -36412,7 +36460,7 @@ snapshots:
   https-proxy-agent@7.0.5:
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -39851,38 +39899,42 @@ snapshots:
       '@types/whatwg-url': 11.0.5
       whatwg-url: 13.0.0
 
-  mongodb-memory-server-core@9.1.7(@aws-sdk/credential-providers@3.620.0(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0))):
+  mongodb-memory-server-core@10.1.2(@aws-sdk/credential-providers@3.620.0(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0)))(socks@2.8.3):
     dependencies:
-      async-mutex: 0.4.1
+      async-mutex: 0.5.0
       camelcase: 6.3.0
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7
       find-cache-dir: 3.3.2
-      follow-redirects: 1.15.6(debug@4.3.6)
+      follow-redirects: 1.15.9(debug@4.3.7)
       https-proxy-agent: 7.0.5
-      mongodb: 5.9.2(@aws-sdk/credential-providers@3.620.0(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0)))
+      mongodb: 6.11.0(@aws-sdk/credential-providers@3.620.0(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0)))(socks@2.8.3)
       new-find-package-json: 2.0.0
       semver: 7.6.3
       tar-stream: 3.1.7
-      tslib: 2.6.3
-      yauzl: 2.10.0
+      tslib: 2.8.1
+      yauzl: 3.2.0
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@mongodb-js/zstd'
+      - gcp-metadata
       - kerberos
       - mongodb-client-encryption
       - snappy
+      - socks
       - supports-color
 
-  mongodb-memory-server@9.1.7(@aws-sdk/credential-providers@3.620.0(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0))):
+  mongodb-memory-server@10.1.2(@aws-sdk/credential-providers@3.620.0(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0)))(socks@2.8.3):
     dependencies:
-      mongodb-memory-server-core: 9.1.7(@aws-sdk/credential-providers@3.620.0(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0)))
-      tslib: 2.6.3
+      mongodb-memory-server-core: 10.1.2(@aws-sdk/credential-providers@3.620.0(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0)))(socks@2.8.3)
+      tslib: 2.8.1
     transitivePeerDependencies:
       - '@aws-sdk/credential-providers'
       - '@mongodb-js/zstd'
+      - gcp-metadata
       - kerberos
       - mongodb-client-encryption
       - snappy
+      - socks
       - supports-color
 
   mongodb@4.16.0(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0)):
@@ -39897,14 +39949,14 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  mongodb@5.9.2(@aws-sdk/credential-providers@3.620.0(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0))):
+  mongodb@6.11.0(@aws-sdk/credential-providers@3.620.0(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0)))(socks@2.8.3):
     dependencies:
-      bson: 5.5.1
-      mongodb-connection-string-url: 2.6.0
-      socks: 2.8.3
+      '@mongodb-js/saslprep': 1.1.9
+      bson: 6.10.0
+      mongodb-connection-string-url: 3.0.1
     optionalDependencies:
       '@aws-sdk/credential-providers': 3.620.0(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0))
-      '@mongodb-js/saslprep': 1.1.8
+      socks: 2.8.3
 
   mongodb@6.4.0(@aws-sdk/credential-providers@3.620.0(@aws-sdk/client-sso-oidc@3.620.0(@aws-sdk/client-sts@3.620.0)))(socks@2.8.3):
     dependencies:
@@ -40019,7 +40071,7 @@ snapshots:
 
   new-find-package-json@2.0.0:
     dependencies:
-      debug: 4.3.6(supports-color@8.1.1)
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -44271,6 +44323,8 @@ snapshots:
 
   tslib@2.6.3: {}
 
+  tslib@2.8.1: {}
+
   tss-react@4.8.8(@emotion/react@11.11.1(@types/react@18.3.1)(react@18.3.1))(@emotion/server@11.10.0)(react@18.3.1):
     dependencies:
       '@emotion/cache': 11.11.0
@@ -45541,6 +45595,11 @@ snapshots:
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
+
+  yauzl@3.2.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      pend: 1.2.0
 
   yjs@13.6.18:
     dependencies:

--- a/setup-after-install.sh
+++ b/setup-after-install.sh
@@ -10,9 +10,3 @@ pnpm nx run-many --target=build --all --skip-nx-cache
 
 echo "Copying .env.example..."
 cp apps/things/assets-catalog/rest-api/.env.example dist/apps/things/assets-catalog/rest-api/.env
-
-docker compose -f ./docker-compose.yml up
-
-# sleep 5
-# # Reference: https://dynamox.atlassian.net/wiki/spaces/DYX/pages/955187256/Testes+de+Carga
-# K6_WEB_DASHBOARD=true k6 run standard-load.js


### PR DESCRIPTION
# What and why was modified?

- [fix(KAIZEN): upgrade mongodb in memory and adjust imports](https://github.com/amaralc/explore/commit/445dd06758b17b913ea24db8a628e3a9be4e2a5f)
  - Tests were failing due to unresolved dependency and imports were referencing wrong folders.

### Reference links and evaluation steps

- Install dependencies;
- Run containers with docker compose up -d
- Run all tests with pnpm nx run-many --target=test
- Verify that all tests pass;
