### PR TITLE
test(COSTS): add tests and split code to different files

### DIFF
--- a/apps/kernel/shared-ts-utils/src/costs/config.ts
+++ b/apps/kernel/shared-ts-utils/src/costs/config.ts
@@ -1,0 +1,6 @@
+export const costStructurePerGbInUSD = {
+  logging: {
+    traffic: 0,
+    monthlyStorage: 0.5,
+  },
+} as const;

--- a/apps/kernel/shared-ts-utils/src/costs/index.spec.ts
+++ b/apps/kernel/shared-ts-utils/src/costs/index.spec.ts
@@ -1,0 +1,69 @@
+import { CostManager } from './index';
+import { costStructurePerGbInUSD } from './config';
+
+describe('CostManager', () => {
+  let costManager: CostManager;
+
+  beforeEach(() => {
+    costManager = new CostManager(costStructurePerGbInUSD);
+  });
+
+  describe('countBytes', () => {
+    it('should correctly count bytes for ASCII string', () => {
+      const input = 'Hello, World!';
+      expect(costManager.countBytes(input)).toBe(13);
+    });
+
+    it('should correctly count bytes for UTF-8 characters', () => {
+      const input = '你好，世界！'; // Chinese characters
+      expect(costManager.countBytes(input)).toBe(18); // Each Chinese character is 3 bytes in UTF-8
+    });
+
+    it('should handle empty string', () => {
+      expect(costManager.countBytes('')).toBe(0);
+    });
+
+    it('should handle null input', () => {
+      expect(costManager.countBytes(null)).toBe(4); // "null" string length
+    });
+
+    it('should return null for non-string/non-null input', () => {
+      expect(costManager.countBytes(123)).toBeNull();
+      expect(costManager.countBytes({})).toBeNull();
+      expect(costManager.countBytes([])).toBeNull();
+      expect(costManager.countBytes(undefined)).toBeNull();
+    });
+  });
+
+  describe('calculateCostInUSD', () => {
+    it('should calculate correct cost for ASCII string', () => {
+      const input = 'Hello, World!'; // 13 bytes
+      // Cost = (storage + traffic) * bytes / 1e6
+      // Cost = (0.5 + 0) * 13 / 1e6 = 6.5e-6
+      expect(costManager.calculateCostInUSD(input)).toBeCloseTo(6.5e-6, 10);
+    });
+
+    it('should calculate correct cost for UTF-8 string', () => {
+      const input = '你好，世界！'; // 18 bytes
+      // Cost = (0.5 + 0) * 18 / 1e6 = 9e-6
+      expect(costManager.calculateCostInUSD(input)).toBeCloseTo(9e-6, 10);
+    });
+
+    it('should handle empty string', () => {
+      expect(costManager.calculateCostInUSD('')).toBe(0);
+    });
+
+    it('should calculate cost for null input', () => {
+      // "null" is 4 bytes
+      // Cost = (0.5 + 0) * 4 / 1e6 = 2e-6
+      expect(costManager.calculateCostInUSD(null)).toBeCloseTo(2e-6, 10);
+    });
+
+    it('should return 0 for non-string/non-null input', () => {
+      expect(costManager.calculateCostInUSD(123)).toBe(0);
+      expect(costManager.calculateCostInUSD({})).toBe(0);
+      expect(costManager.calculateCostInUSD([])).toBe(0);
+      expect(costManager.calculateCostInUSD(undefined)).toBe(0);
+    });
+  });
+});

--- a/apps/kernel/shared-ts-utils/src/costs/index.ts
+++ b/apps/kernel/shared-ts-utils/src/costs/index.ts
@@ -1,17 +1,8 @@
-abstract class AbstractCostManager {
-  abstract countBytes(inputDto: unknown): number | null;
+import { costStructurePerGbInUSD } from './config';
 
-  abstract calculateCostInUSD(inputDto: unknown): number;
-}
+export { costStructurePerGbInUSD };
 
-const costStructurePerGbInUSD = {
-  logging: {
-    traffic: 0,
-    monthlyStorage: 0.5,
-  },
-} as const;
-
-export class CostManager implements AbstractCostManager {
+export class CostManager {
   constructor(private readonly costStructure: typeof costStructurePerGbInUSD) {}
 
   calculateCostInUSD(inputDto: unknown): number {


### PR DESCRIPTION
# What and why was modified?

- Removed the unnecessary AbstractCostManager class from the CostManager implementation
- The abstraction was adding complexity without providing significant benefits
- CostManager now stands as a concrete implementation focused on its specific use case
- This change improves code readability and reduces unnecessary abstraction layers

### Reference links and evaluation steps

- Run the unit tests: pnpm nx test kernel-shared-ts-utils --testFile=src/costs
- Verify that all tests pass, including:
- Byte counting for ASCII and UTF-8 strings
- Cost calculations for various input types
- Edge case handling (null, empty strings, objects)
- Confirm that the cost calculation results remain unchanged for all input types
