### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,78 +1,18 @@
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "targetDefaults": {
-    "build": {
-      "dependsOn": [
-        "^build"
-      ],
-      "inputs": [
-        "production",
-        "^production"
-      ],
-      "cache": true
-    },
-    "test": {
-      "inputs": [
-        "default",
-        "^production",
-        "{workspaceRoot}/jest.preset.js"
-      ],
-      "cache": true
-    },
-    "e2e": {
-      "inputs": [
-        "default",
-        "^production"
-      ],
-      "cache": true
-    },
-    "production-terraform-init": {
-      "cache": true
-    },
-    "production-terraform-validate": {
-      "cache": true
-    },
-    "@nx/vite:test": {
-      "inputs": [
-        "default",
-        "^production",
-        "{workspaceRoot}/jest.preset.js"
-      ],
-      "cache": true
-    },
-    "@nx/eslint:lint": {
-      "inputs": [
-        "default",
-        "{workspaceRoot}/.eslintrc.json"
-      ],
-      "cache": true
-    },
-    "@nx/webpack:webpack": {
-      "cache": true,
-      "dependsOn": [
-        "^build"
-      ],
-      "inputs": [
-        "production",
-        "^production"
-      ]
-    },
-    "@nx/esbuild:esbuild": {
-      "cache": true,
-      "dependsOn": [
-        "^build"
-      ],
-      "inputs": [
-        "production",
-        "^production"
-      ]
-    }
+    "build": { "dependsOn": ["^build"], "inputs": ["production", "^production"], "cache": true },
+    "test": { "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"], "cache": true },
+    "e2e": { "inputs": ["default", "^production"], "cache": true },
+    "production-terraform-init": { "cache": true },
+    "production-terraform-validate": { "cache": true },
+    "@nx/vite:test": { "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"], "cache": true },
+    "@nx/eslint:lint": { "inputs": ["default", "{workspaceRoot}/.eslintrc.json"], "cache": true },
+    "@nx/webpack:webpack": { "cache": true, "dependsOn": ["^build"], "inputs": ["production", "^production"] },
+    "@nx/esbuild:esbuild": { "cache": true, "dependsOn": ["^build"], "inputs": ["production", "^production"] }
   },
   "namedInputs": {
-    "default": [
-      "{projectRoot}/**/*",
-      "sharedGlobals"
-    ],
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
     "production": [
       "default",
       "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
@@ -84,35 +24,17 @@
       "!{projectRoot}/.storybook/**/*",
       "!{projectRoot}/tsconfig.storybook.json"
     ],
-    "sharedGlobals": [
-      "{workspaceRoot}/babel.config.json"
-    ]
+    "sharedGlobals": ["{workspaceRoot}/babel.config.json"]
   },
   "generators": {
     "@nx/react": {
-      "application": {
-        "babel": true,
-        "style": "@emotion/styled",
-        "linter": "eslint",
-        "bundler": "vite"
-      },
-      "component": {
-        "style": "@emotion/styled"
-      },
-      "library": {
-        "style": "@emotion/styled",
-        "linter": "eslint",
-        "unitTestRunner": "jest"
-      }
+      "application": { "babel": true, "style": "@emotion/styled", "linter": "eslint", "bundler": "vite" },
+      "component": { "style": "@emotion/styled" },
+      "library": { "style": "@emotion/styled", "linter": "eslint", "unitTestRunner": "jest" }
     },
-    "@nx/next": {
-      "application": {
-        "style": "css",
-        "linter": "eslint"
-      }
-    }
+    "@nx/next": { "application": { "style": "css", "linter": "eslint" } }
   },
-  "nxCloudAccessToken": "fake-token",
+  "nxCloudAccessToken": "YzhjNThiYzEtM2EyNS00MDMxLWExNTQtOWEwNjdjZGE3M2MxfHJlYWQtd3JpdGU=",
   "plugins": [
     {
       "plugin": "@nx/vite/plugin",
@@ -124,12 +46,7 @@
         "serveStaticTargetName": "serve-static"
       }
     },
-    {
-      "plugin": "@nx/eslint/plugin",
-      "options": {
-        "targetName": "lint"
-      }
-    },
+    { "plugin": "@nx/eslint/plugin", "options": { "targetName": "lint" } },
     {
       "plugin": "@nx/storybook/plugin",
       "options": {
@@ -142,19 +59,10 @@
   ],
   "release": {
     "releaseTagPattern": "peerlab@{version}",
-    "git": {
-      "commitMessage": "chore(release): [skip-github-pipeline]"
-    },
-    "version": {
-      "conventionalCommits": true
-    },
-    "changelog": {
-      "projectChangelogs": false,
-      "workspaceChangelog": true
-    },
-    "projects": [
-      "."
-    ],
+    "git": { "commitMessage": "chore(release): [skip-github-pipeline]" },
+    "version": { "conventionalCommits": true },
+    "changelog": { "projectChangelogs": false, "workspaceChangelog": true },
+    "projects": ["."],
     "projectsRelationship": "fixed"
   }
 }


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/64a9aea8097e04000dd003de/workspaces/6980d7cd9c1e40bdae8ccd8f

> [!TIP]
> Run `npx nx generate ci-workflow` if you don't have a CI script configured yet.

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.