### PR TITLE
fix: increase MongoDB memory server timeout in taxonomic-unit tests

### DIFF
--- a/teams/things/assets-catalog/base/src/domains/taxonomic-units-v1/core/use-cases/create-taxonomic-unit/index.spec.ts
+++ b/teams/things/assets-catalog/base/src/domains/taxonomic-units-v1/core/use-cases/create-taxonomic-unit/index.spec.ts
@@ -17,7 +17,7 @@ describe('Create TaxonomicUnitV1 with free plan subscription', () => {
     mongoDbMemoryServer = result.mongoMemoryServer;
     mongoDbDriver = new MongoDbDriver(result.databaseUri);
     await mongoDbDriver.connectToDatabase('test-database');
-  });
+  }, 30000);
   beforeEach(async () => {
     taxonomicUnitsV1DatabaseRepository = new MongoDbTaxonomicUnitsV1DatabaseRepository(mongoDbDriver);
     await taxonomicUnitsV1DatabaseRepository.generateIndexes();
@@ -29,7 +29,7 @@ describe('Create TaxonomicUnitV1 with free plan subscription', () => {
   afterAll(async () => {
     await mongoDbDriver.disconnect();
     await mongoDbMemoryServer.stop();
-  });
+  }, 15000);
   it('should create a taxonomic unit', async () => {
     const createOrganizationInputDto: ICreateTaxonomicUnitV1InputDto = {
       slug: 'valid-taxonomic-unit-slug',


### PR DESCRIPTION
## Summary
- Increase `beforeAll` timeout to 30s for MongoDB memory server initialization which can exceed the default 5s Jest timeout
- Increase `afterAll` timeout to 15s for server teardown

Closes #149

## Test plan
- [x] Verify `nx test things-assets-catalog-base` passes without timeout errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)