### PR TITLE
fix(ci): add NX cache population job to build-and-deploy pipeline

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -12,6 +12,54 @@ permissions:
   contents: read
 
 jobs:
+  nx-cache:
+    runs-on: ubuntu-latest
+    environment: main
+
+    env:
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Cache pnpm store
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Prisma client
+        run: pnpm prisma:generate:postgres
+
+      - name: Lint
+        run: pnpm nx run-many --target=lint --all=true
+
+      - name: Test
+        run: pnpm nx run-many --target=test --all=true
+
+      - name: Build
+        run: pnpm nx run-many --target=build --all=true
+
   build:
     if: false # Disabled
     runs-on: ubuntu-latest
@@ -105,16 +153,19 @@ jobs:
             ${{ secrets.GCP_LOCATION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ secrets.GCP_DOCKER_ARTIFACT_REPOSITORY_NAME }}/things-assets-catalog-rest-api:${{ env.short_commit_sha }}
 
   deploy:
-    # needs: [build]
+    needs: [nx-cache]
     if: true # Enabled
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: ${{ github.workspace }}
 
+    env:
+      NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Checkout all branches and tags
 
@@ -156,23 +207,19 @@ jobs:
           gcloud auth activate-service-account --key-file=teams/kernel/shell-iac/production/credentials.json
 
       - name: Install Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version-file: '.nvmrc'
 
-      - uses: pnpm/action-setup@v2
-        name: Install pnpm
-        with:
-          version: '8.9.1'
-          run_install: false
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
       - name: Get pnpm store directory
         shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
 
-      - uses: actions/cache@v3
-        name: Setup pnpm cache
+      - name: Cache pnpm store
+        uses: actions/cache@v4
         with:
           path: ${{ env.STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/docs/insights-short-term.md
+++ b/docs/insights-short-term.md
@@ -2,6 +2,12 @@
 
 Latest 100 insights derived from recent project activity, newest first.
 
+- [2026-02-04 03:20 UTC] Issue #163 tracks adding NX cache job to build-and-deploy pipeline
+- [2026-02-04 03:15 UTC] NX cache job gates deploy to ensure lint/test/build pass first
+- [2026-02-04 03:15 UTC] GitHub env with NX read-write token enables shared cache across jobs
+- [2026-02-04 03:15 UTC] `needs:` in Actions enforces job execution order and dependency gating
+- [2026-02-04 03:10 UTC] Modernizing action versions (v3->v4) aligns deploy with CI patterns
+- [2026-02-04 03:10 UTC] Using .nvmrc for Node version avoids hardcoded drift across workflows
 - [2026-02-04 02:50 UTC] PR #162 re-adds CodeQL workflow with JS/TS and Actions scanning
 - [2026-02-04 02:45 UTC] `git show <commit>^:<file>` recovers content deleted in prior commits
 - [2026-02-04 02:35 UTC] Issue #161 tracks re-adding CodeQL workflow after PR #158 removal
@@ -96,10 +102,4 @@ Latest 100 insights derived from recent project activity, newest first.
 - [2025-01-11 19:27 UTC] Backward compatibility validation added to JSON schema validator
 - [2025-01-11 13:34 UTC] Setup speed improvements shorten feedback loop for developers
 - [2025-01-11 13:27 UTC] Removing Docker init requirement speeds up fresh installations
-- [2025-01-11 13:20 UTC] Reduced setup time directly improves developer onboarding speed
-- [2024-12-10 02:35 UTC] Nanoid 3.3.8 patches predictable ID generation vulnerability
-- [2024-12-01 02:34 UTC] Next.js 15.0.3 upgrade enables latest React server components
-- [2024-11-30 23:31 UTC] Express 4.21.0 merge resolves upstream security patch
-- [2024-11-30 23:29 UTC] Vite 5.2.14 merge patches dev server security vulnerabilities
-- [2024-11-30 23:26 UTC] Express 4.20.0 intermediate merge validates upgrade path
 


### PR DESCRIPTION
## Summary
- Add `nx-cache` job that runs lint, test, and build on all projects in a `main` environment with NX Cloud read-write token
- Gate the `deploy` job on `nx-cache` via `needs:` so deployment only proceeds after checks pass
- Modernize action versions (v3 → v4) and use `.nvmrc` for Node version in the deploy job

## Test plan
- [x] Verify `main` GitHub environment exists with `NX_CLOUD_ACCESS_TOKEN` secret
- [x] Trigger workflow via tag creation and confirm `nx-cache` job runs first
- [x] Confirm `deploy` job waits for `nx-cache` and gets NX cache hits on build step

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)