### PR TITLE
ci: add manually triggered graduate release workflow

### DIFF
--- a/.github/workflows/graduate.yml
+++ b/.github/workflows/graduate.yml
@@ -1,0 +1,59 @@
+name: Graduate Release
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+
+jobs:
+  graduate:
+    runs-on: ubuntu-latest
+    environment: main
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Install Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@c5ba7f7862a0f64c1b1a05fbac13e0b8e86ba08c # v4
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Cache pnpm store
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Graduate Release
+        run: pnpm graduate
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
+      - name: Push Release Commit and Tags
+        run: |
+          git push
+          git push --tags


### PR DESCRIPTION
<!-- any-pr -->

# What and why was modified?

- Added a `graduate.yml` workflow to promote beta prereleases to stable versions via a manual trigger
- The CI workflow already auto-creates beta prereleases on merge to main, but there is no way to graduate them to stable without manual CLI intervention (obstacle #212)

# How was it modified?

- Created `.github/workflows/graduate.yml` with `workflow_dispatch` trigger
- Workflow runs `pnpm graduate` (`nx release --skip-publish`), then pushes the commit and tags to main
- Gated by `environment: main` so only admins can trigger it

### Reference links and evaluation steps

- Merge this PR to main and wait for beta prerelease to be created by CI
- Navigate to Actions → "Graduate Pre-Release" → "Run workflow"
- Verify stable version commit and tag are pushed to main
- Verify changelog is updated with the graduated version

<!-- experiment record pr -->

## Experiment Record

| Field | Details |
|-------|---------|
| **Date and step** | _See title and iteration or date field_ |
| **Expected result and how to measure** | Clicking "Run workflow" on the Graduate Pre-Release action should: (1) graduate the current beta to a stable version, (2) update the changelog, (3) create and push a release commit and tag to main. Measurable by checking git tags and CHANGELOG.md after the run. |
| **Coach** | <ul><li>[x] N/A</li></ul> |
| **Type of experiment** | <ul><li>[x] Testing hypothesis</li></ul> |
| **What happened** | _To be filled after experiment_ |
| **What did we learn** | _To be filled after experiment_ |


## Next step

<!-- Based on what we learned, what is the next experiment? Link to the new issue if created. -->
_To be filled after experiment_

🤖 Generated with [Claude Code](https://claude.com/claude-code)