### PR TITLE
fix: add manifestRootsToUpdate to nx.json release config

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -149,7 +149,10 @@
       "commitMessage": "chore(release): [skip-github-pipeline]"
     },
     "version": {
-      "conventionalCommits": true
+      "conventionalCommits": true,
+      "manifestRootsToUpdate": [
+        "."
+      ]
     },
     "changelog": {
       "workspaceChangelog": {


### PR DESCRIPTION
## Summary
- Adds `manifestRootsToUpdate: ["."]` to NX Release version config in nx.json
- Ensures `nx release` writes version bumps to the root package.json
- Linked to #212

## Test plan
- [ ] Verify `nx release --dry-run` picks up root package.json for version updates
- [ ] Confirm CI pipeline passes with the updated nx.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)