### PR TITLE
config: include chore and config commit types in changelog

### DIFF
--- a/docs/insights-short-term.md
+++ b/docs/insights-short-term.md
@@ -2,6 +2,7 @@
 
 Latest 100 insights derived from recent project activity, newest first.
 
+- [2026-02-09 21:45 UTC] NX hides `chore` by default; override via `release.conventionalCommits.types` in nx.json
 - [2026-02-09 19:30 UTC] Fresh cluster bootstraps skip incremental upgrade paths; migrate only in-place
 - [2026-02-09 19:15 UTC] provider-kubernetes v1.2.0+ requires Crossplane 2.0+; upgrade both together
 - [2026-02-09 18:45 UTC] Pinned image versions drift across modules; grep all references before upgrading
@@ -101,5 +102,4 @@ Latest 100 insights derived from recent project activity, newest first.
 - [2026-02-04 21:08 UTC] Map CI/CD pain points to DORA metrics for measurable target conditions
 - [2026-02-04 20:48 UTC] Scope target condition issues to a single obstacle from the parent milestone
 - [2026-02-05 04:30 UTC] `gh api --method PATCH` updates GitHub milestone descriptions programmatically
-- [2026-02-05 04:15 UTC] Unified current-vs-target tables replace separate condition sections in Kata docs
 

--- a/nx.json
+++ b/nx.json
@@ -145,6 +145,24 @@
     }
   ],
   "release": {
+    "conventionalCommits": {
+      "types": {
+        "chore": {
+          "semverBump": "none",
+          "changelog": {
+            "hidden": false,
+            "title": "Chore"
+          }
+        },
+        "config": {
+          "semverBump": "none",
+          "changelog": {
+            "hidden": false,
+            "title": "Configuration"
+          }
+        }
+      }
+    },
     "git": {
       "commitMessage": "chore(release): [skip-github-pipeline]"
     },


### PR DESCRIPTION
## Summary
- Add `release.conventionalCommits.types` config to `nx.json` to unhide `chore` and `config` commit types from the generated changelog
- Both types use `semverBump: "none"` so they don't trigger version bumps
- NX defaults hide `chore` and don't recognize `config` at all — this override fixes both

Closes #230

## Test plan
- [ ] Run `pnpm release:no-push` and verify `chore` and `config` commits appear in changelog output
- [ ] Confirm no version bump occurs for commits using these types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on configuring NX release settings for conventional commit types in changelog generation.

* **Chores**
  * Updated release configuration to define how different commit types are processed and displayed in changelogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->