### PR TITLE
fix(iac): resolve terraform-google-modules/project-factory version constraints

### DIFF
--- a/docs/insights-short-term.md
+++ b/docs/insights-short-term.md
@@ -2,6 +2,7 @@
 
 Latest 100 insights derived from recent project activity, newest first.
 
+- [2026-02-12 23:50 UTC] Nested module version constraints combine; parent versions.tf must satisfy all
 - [2026-02-12 23:45 UTC] Dependent deploy jobs with artifact passing enable approval gates cleanly
 - [2026-02-12 23:40 UTC] GitHub environment protection rules gate deployments without splitting workflows
 - [2026-02-12 23:30 UTC] Use git rev-parse --short=8 HEAD after push to capture release commit, not trigger SHA
@@ -101,4 +102,3 @@ Latest 100 insights derived from recent project activity, newest first.
 - [2026-02-06 23:30 UTC] `gh issue comment` adds lessons learned to experiment issues for future reference
 - [2026-02-06 23:25 UTC] Schedule-only triggers for security scans reduce CI noise without sacrificing coverage
 - [2026-02-06 23:20 UTC] Same commit triggers multiple workflows independently; check workflow name to distinguish runs
-- [2026-02-06 23:15 UTC] Add explicit `permissions: contents: read` to workflows for least-privilege security

--- a/teams/kernel/shell-iac/draft/projects.tf
+++ b/teams/kernel/shell-iac/draft/projects.tf
@@ -1,6 +1,6 @@
 module "cs-vpc-host-prod-ha468-pm749" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 14.2"
+  version = "18.2.0"
 
   name       = "vpc-host-prod"
   project_id = "vpc-host-prod-ha468-pm749"
@@ -13,7 +13,7 @@ module "cs-vpc-host-prod-ha468-pm749" {
 
 module "cs-vpc-host-nonprod-ha468-pm749" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 14.2"
+  version = "18.2.0"
 
   name       = "vpc-host-nonprod"
   project_id = "vpc-host-nonprod-ha468-pm749"
@@ -26,7 +26,7 @@ module "cs-vpc-host-nonprod-ha468-pm749" {
 
 module "cs-logging-ha468-pm749" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 14.2"
+  version = "18.2.0"
 
   name       = "logging"
   project_id = "logging-ha468-pm749"
@@ -38,7 +38,7 @@ module "cs-logging-ha468-pm749" {
 
 module "cs-monitoring-prod-ha468-pm749" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 14.2"
+  version = "18.2.0"
 
   name       = "monitoring-prod"
   project_id = "monitoring-prod-ha468-pm749"
@@ -50,7 +50,7 @@ module "cs-monitoring-prod-ha468-pm749" {
 
 module "cs-monitoring-nonprod-ha468-pm749" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 14.2"
+  version = "18.2.0"
 
   name       = "monitoring-nonprod"
   project_id = "monitoring-nonprod-ha468-pm749"
@@ -62,7 +62,7 @@ module "cs-monitoring-nonprod-ha468-pm749" {
 
 module "cs-monitoring-dev-ha468-pm749" {
   source  = "terraform-google-modules/project-factory/google"
-  version = "~> 14.2"
+  version = "18.2.0"
 
   name       = "monitoring-dev"
   project_id = "monitoring-dev-ha468-pm749"

--- a/teams/kernel/shell-iac/draft/service-projects.tf
+++ b/teams/kernel/shell-iac/draft/service-projects.tf
@@ -1,6 +1,6 @@
 module "cs-svc-kernel-prod-svc-czzc" {
   source  = "terraform-google-modules/project-factory/google//modules/svpc_service_project"
-  version = "~> 14.2"
+  version = "18.2.0"
 
   name            = "kernel-prod-service"
   project_id      = "kernel-prod-svc-czzc"
@@ -20,7 +20,7 @@ module "cs-svc-kernel-prod-svc-czzc" {
 
 module "cs-svc-kernel-nonprod-svc-czzc" {
   source  = "terraform-google-modules/project-factory/google//modules/svpc_service_project"
-  version = "~> 14.2"
+  version = "18.2.0"
 
   name            = "kernel-nonprod-service"
   project_id      = "kernel-nonprod-svc-czzc"
@@ -40,7 +40,7 @@ module "cs-svc-kernel-nonprod-svc-czzc" {
 
 module "cs-svc-organizations-prod-svc-czzc" {
   source  = "terraform-google-modules/project-factory/google//modules/svpc_service_project"
-  version = "~> 14.2"
+  version = "18.2.0"
 
   name            = "organizations-prod-service"
   project_id      = "organizations-prod-svc-czzc"
@@ -60,7 +60,7 @@ module "cs-svc-organizations-prod-svc-czzc" {
 
 module "cs-svc-organizations-nonprod-svc-czzc" {
   source  = "terraform-google-modules/project-factory/google//modules/svpc_service_project"
-  version = "~> 14.2"
+  version = "18.2.0"
 
   name            = "organizations-nonprod-service"
   project_id      = "organizations-nonprod-svc-czzc"


### PR DESCRIPTION
## Summary
- Upgrade `terraform-google-modules/project-factory` from `~> 14.2` to `18.2.0` to fix provider version conflicts
- Version 14.2 requires google provider `< 6.0.0`, which conflicts with production's pinned `7.19.0`
- Version 18.2.0 supports google provider 7.19.0 and later

## Root Cause
Nested module version constraints combine at terraform init. When production's `versions.tf` specifies `google = "7.19.0"`, but transitive dependencies (like project-factory 14.2) require `>= 3.45.0, < 6.0.0`, terraform cannot resolve the conflicting constraints.

## Test Plan
- [ ] Verify terraform init succeeds with production environment configuration
- [ ] Confirm no provider version warnings in terraform plan
- [ ] Review module compatibility notes for project-factory 18.2.0

## References
Relates to #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added recent insights entries from February 11-12, 2026 to the knowledge base. Removed outdated entries to maintain current information relevance.

* **Chores**
  * Upgraded infrastructure module versions to 18.2.0 across VPC host, logging, monitoring, and service project configurations in production, non-production, and development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->