### PR TITLE
fix(iac): resolve terraform-google-modules/project-factory version constraints (#196)

### DIFF
--- a/teams/kernel/shell-iac/draft/folders.tf
+++ b/teams/kernel/shell-iac/draft/folders.tf
@@ -1,6 +1,6 @@
 module "cs-common" {
   source  = "terraform-google-modules/folders/google"
-  version = "~> 3.2"
+  version = "5.1.0"
 
   parent = "organizations/${var.org_id}"
   names = [
@@ -10,7 +10,7 @@ module "cs-common" {
 
 module "cs-teams" {
   source  = "terraform-google-modules/folders/google"
-  version = "~> 3.2"
+  version = "5.1.0"
 
   parent = "organizations/${var.org_id}"
   names = [
@@ -22,7 +22,7 @@ module "cs-teams" {
 module "cs-envs" {
   for_each = module.cs-teams.ids
   source   = "terraform-google-modules/folders/google"
-  version  = "~> 3.2"
+  version  = "5.1.0"
 
   parent = each.value
   names = [

--- a/teams/kernel/shell-iac/production/main.tf
+++ b/teams/kernel/shell-iac/production/main.tf
@@ -9,7 +9,7 @@ locals {
 
 module "common_folder" {
   source  = "terraform-google-modules/folders/google"
-  version = "4.0.1"
+  version = "5.1.0"
 
   parent = "organizations/${var.gcp_organization_id}"
   names = [
@@ -19,7 +19,7 @@ module "common_folder" {
 
 module "teams_folders" {
   source  = "terraform-google-modules/folders/google"
-  version = "4.0.1"
+  version = "5.1.0"
 
   parent = "organizations/${var.gcp_organization_id}"
   names = [
@@ -31,7 +31,7 @@ module "teams_folders" {
 module "environments_folders" {
   for_each = module.teams_folders.ids
   source   = "terraform-google-modules/folders/google"
-  version  = "4.0.1"
+  version  = "5.1.0"
 
   parent = each.value
   names = [


### PR DESCRIPTION
# What and why was modified?

- Upgraded `terraform-google-modules/project-factory` from `~> 14.2` to `18.2.0` to fix version constraint conflicts
- Version 14.2 requires google provider `< 6.0.0`, which conflicts with production's pinned version `7.19.0`
- Version 18.2.0 supports google provider 7.19.0+ and later, enabling consistent provider versions across environments

# How was it modified?

- Updated `teams/kernel/shell-iac/draft/projects.tf`: all 6 module versions changed to `18.2.0`
- Updated `teams/kernel/shell-iac/draft/service-projects.tf`: all 4 module versions changed to `18.2.0`
- Root cause: Nested module version constraints combine at `terraform init`. When production specifies exact version `google = "7.19.0"`, transitive dependencies with incompatible ranges cause resolution failure

### Reference links and evaluation steps

- Run `terraform init` in production environment to verify no version conflicts
- Run `terraform plan` to confirm no provider warnings
- Review [terraform-google-modules/project-factory v18.2.0 release notes](https://github.com/terraform-google-modules/terraform-google-project-factory/releases/tag/v18.2.0)

<!-- experiment record pr -->

## Experiment Record

| Field | Details |
|-------|----|
| **Date and step** | Infrastructure dependency resolution for terraform-google-modules/project-factory v18.2.0 compatibility |
| **Expected result and how to measure** | terraform init succeeds without version constraint errors; terraform plan shows no provider warnings |
| **Coach** | <ul><li>[ ] N/A</li></ul> |
| **Type of experiment** | <ul><li>[x] Testing hypothesis</li></ul> |
| **What happened** | Diagnosed version constraint conflict: project-factory 14.2 requires `>= 3.45.0, < 6.0.0` but production uses `7.19.0` |
| **What did we learn** | Nested module version constraints combine at terraform init; parent versions.tf must satisfy all transitive dependencies |

## Next step

Verify terraform operations succeed with updated versions across all IaC modules.

Closes #196

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure module dependencies to the latest versions (5.1.0) for improved compatibility and stability across deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->