### PR TITLE
fix(iac): grant org-level folderAdmin role in bootstrap script

### DIFF
--- a/docs/insights-short-term.md
+++ b/docs/insights-short-term.md
@@ -2,6 +2,8 @@
 
 Latest 100 insights derived from recent project activity, newest first.
 
+- [2026-02-13 00:30 UTC] Bootstrap scripts must grant org-level folderAdmin role for Terraform folder.create
+- [2026-02-13 00:25 UTC] Terraform folder creation needs org-level folderAdmin role; project-level insufficient
 - [2026-02-13 00:18 UTC] PR experiment comments capture complete troubleshooting journey for team organizational learning
 - [2026-02-13 00:15 UTC] GitHub Actions workflow step order critical; auth must precede credential-dependent operations
 - [2026-02-13 00:12 UTC] Terraform init requires prior GCP authentication for GCS backend access in CI workflows
@@ -100,5 +102,3 @@ Latest 100 insights derived from recent project activity, newest first.
 - [2026-02-07 20:00 UTC] Renderers can detect graduation by comparing current stable version against previous prerelease tag
 - [2026-02-07 19:30 UTC] Graduating prereleases duplicates changelog entries already logged under beta versions
 - [2026-02-07 19:15 UTC] `manifestRootsToUpdate: ["."]` redirects NX Release version writes to root package.json
-- [2026-02-07 18:45 UTC] NX Release `projects: ["."]` fails silently without root project.json; omit for defaults
-- [2026-02-07 18:30 UTC] NX Release enforces `currentVersionResolver: "git-tag"` when using conventional commits

--- a/teams/kernel/shell-iac/project-setup.sh
+++ b/teams/kernel/shell-iac/project-setup.sh
@@ -343,6 +343,8 @@ gcloud projects add-iam-policy-binding $GCP_PROJECT_ID --member="serviceAccount:
 gcloud projects add-iam-policy-binding $GCP_PROJECT_ID --member="serviceAccount:$GCP_SERVICE_ACCOUNT_EMAIL" --role="roles/source.admin" > /dev/null # Necessary to use google_iap_brand and client resources (https://cloud.google.com/iap/docs/programmatic-oauth-clients)
 gcloud projects add-iam-policy-binding $GCP_PROJECT_ID --member="serviceAccount:$GCP_SERVICE_ACCOUNT_EMAIL" --role="roles/dns.admin" > /dev/null # Admin DNS records
 gcloud organizations add-iam-policy-binding "$GCP_ORGANIZATION_ID" --member="serviceAccount:$GCP_SERVICE_ACCOUNT_EMAIL" --role="roles/resourcemanager.organizationViewer" > /dev/null
+gcloud organizations add-iam-policy-binding "$GCP_ORGANIZATION_ID" --member="serviceAccount:$GCP_SERVICE_ACCOUNT_EMAIL" --role="roles/resourcemanager.folderAdmin" > /dev/null
+
 echo "Granted required roles to service account."
 
 # Create a support group email (skip if it already exists)


### PR DESCRIPTION
## Summary

Service accounts need `roles/resourcemanager.folderAdmin` at the organization level to create folders in Terraform. Added this org-level IAM role binding to the bootstrap script.

## Changes

- Added `gcloud organizations add-iam-policy-binding` command to grant `roles/resourcemanager.folderAdmin` to the service account at the org level
- Updated project insights to document the pattern

## Test plan

- [x] Bootstrap script now grants org-level folderAdmin role before Terraform operations
- [x] Terraform folder.create operations should succeed with this role binding
- [x] Follows idempotent pattern (subsequent runs skip if role already bound)

## Related

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated insights with new requirements regarding IAM role permissions for infrastructure operations.
  * Removed outdated insights related to previous infrastructure release issues.

* **Chores**
  * Enhanced setup script to include organization-level IAM role bindings during infrastructure initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->