### PR TITLE
fix(ci): secure Terraform backend configuration and workflow permissions

### DIFF
--- a/.github/workflows/teams-kernel-workflows-deploy-team.yml
+++ b/.github/workflows/teams-kernel-workflows-deploy-team.yml
@@ -91,6 +91,22 @@ jobs:
       - name: Generate Prisma client
         run: pnpm prisma:generate:postgres
 
+      - name: Generate Terraform Backend Configuration
+        working-directory: ${{ inputs.iac-path }}
+        env:
+          GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+        run: |
+          cat > backend.tf <<EOF
+          # This block sets up what backend should be used for Terraform. In this case, we are using Google Cloud Storage.
+          terraform {
+            backend "gcs" {                                # The Google Cloud Storage backend
+              bucket = "$GCP_PROJECT_ID-tfstate"           # The name of the bucket to store the state file
+              prefix = "production"                        # The path to the state file within the bucket
+              # Authentication uses Application Default Credentials (ADC) from Workload Identity Federation
+            }
+          }
+          EOF
+
       - name: Authenticate to Google Cloud
         id: auth
         uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13

--- a/.github/workflows/teams-kernel-workflows-deploy-team.yml
+++ b/.github/workflows/teams-kernel-workflows-deploy-team.yml
@@ -21,7 +21,7 @@ on:
       DOMAIN_NAME:
         required: false
       GCP_PROJECT_ID:
-        required: false
+        required: true
       GCP_LOCATION:
         required: false
       SUPPORT_ACCOUNT_EMAIL:
@@ -96,6 +96,11 @@ jobs:
         env:
           GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
         run: |
+          if [ -z "$GCP_PROJECT_ID" ]; then
+            echo "❌ Error in 'Generate Terraform Backend Configuration' step: GCP_PROJECT_ID environment variable is empty"
+            echo "   This variable is required to generate backend.tf configuration"
+            exit 1
+          fi
           cat > backend.tf <<EOF
           # This block sets up what backend should be used for Terraform. In this case, we are using Google Cloud Storage.
           terraform {
@@ -106,6 +111,7 @@ jobs:
             }
           }
           EOF
+          echo "✓ Terraform backend configuration (backend.tf) generated successfully."
 
       - name: Authenticate to Google Cloud
         id: auth

--- a/.github/workflows/teams-kernel-workflows-deploy.yml
+++ b/.github/workflows/teams-kernel-workflows-deploy.yml
@@ -77,6 +77,7 @@ jobs:
     name: Deploy Kernel Team
     permissions:
       contents: read
+      id-token: write
     needs: build
     uses: ./.github/workflows/teams-kernel-workflows-deploy-team.yml
     secrets:
@@ -105,6 +106,7 @@ jobs:
     name: Deploy People Team
     permissions:
       contents: read
+      id-token: write
     needs: deploy-kernel
     if: needs.deploy-kernel.result == 'success'
     uses: ./.github/workflows/teams-kernel-workflows-deploy-team.yml
@@ -135,6 +137,7 @@ jobs:
     needs: deploy-kernel
     permissions:
       contents: read
+      id-token: write
     if: needs.deploy-kernel.result == 'success'
     uses: ./.github/workflows/teams-kernel-workflows-deploy-team.yml
     secrets:

--- a/docs/insights-short-term.md
+++ b/docs/insights-short-term.md
@@ -2,6 +2,9 @@
 
 Latest 100 insights derived from recent project activity, newest first.
 
+- [2026-02-15 17:15 UTC] Backend config generation belongs in CI/CD workflows using secrets, not open-source bootstrap
+- [2026-02-15 16:45 UTC] Reusable workflows require calling job to grant `id-token: write` for OIDC authentication
+- [2026-02-15 15:30 UTC] Choose Terraform for simplicity & multi-cloud; Pulumi for complex logic in familiar languages
 - [2026-02-15 14:00 UTC] Move secrets from run blocks to env: to enable GitHub masking
 - [2026-02-14 14:35 UTC] Combine job needs with needs.X.result == 'success' to enforce deployment success
 - [2026-02-14 14:30 UTC] Complete security fixes end-to-end: implement, test, commit, push for compliance
@@ -99,6 +102,3 @@ Latest 100 insights derived from recent project activity, newest first.
 - [2026-02-10 16:00 UTC] K8s Ingress is an L7 reverse proxy routing external HTTP traffic to services via host/path rules
 - [2026-02-10 10:00 UTC] `moved` blocks + sibling modules cleanly split monolithic TF modules without state recreation
 - [2026-02-10 09:15 UTC] Crossplane is a platform layer on any K8s cluster (minikube, GKE, EKS), not env-specific infra
-- [2026-02-10 09:00 UTC] Separate infra provisioners (Crossplane) from service modules (IAM) so multiple services reuse them
-- [2026-02-10 08:30 UTC] Two-phase TF apply: targeted `-target` installs CRDs, then full apply plans resources needing them
-- [2026-02-10 08:00 UTC] Placeholder provider blocks with dummy tokens satisfy TF init for count=0 cloud modules

--- a/docs/insights-short-term.md
+++ b/docs/insights-short-term.md
@@ -2,6 +2,8 @@
 
 Latest 100 insights derived from recent project activity, newest first.
 
+- [2026-02-15 18:00 UTC] Validate required secrets before use; fail fast with error naming step and target file
+- [2026-02-15 17:45 UTC] Document infrastructure changes via PR Experiment Record for organizational learning
 - [2026-02-15 17:15 UTC] Backend config generation belongs in CI/CD workflows using secrets, not open-source bootstrap
 - [2026-02-15 16:45 UTC] Reusable workflows require calling job to grant `id-token: write` for OIDC authentication
 - [2026-02-15 15:30 UTC] Choose Terraform for simplicity & multi-cloud; Pulumi for complex logic in familiar languages
@@ -100,5 +102,3 @@ Latest 100 insights derived from recent project activity, newest first.
 - [2026-02-10 17:00 UTC] Local infra layers: cluster → Crossplane → service resources → app workloads (strict order)
 - [2026-02-10 16:30 UTC] Kong can be the K8s Ingress Controller or sit behind one for API-subset routing
 - [2026-02-10 16:00 UTC] K8s Ingress is an L7 reverse proxy routing external HTTP traffic to services via host/path rules
-- [2026-02-10 10:00 UTC] `moved` blocks + sibling modules cleanly split monolithic TF modules without state recreation
-- [2026-02-10 09:15 UTC] Crossplane is a platform layer on any K8s cluster (minikube, GKE, EKS), not env-specific infra

--- a/teams/kernel/iac/production/backend.tf
+++ b/teams/kernel/iac/production/backend.tf
@@ -1,8 +1,8 @@
 # This block sets up what backend should be used for Terraform. In this case, we are using Google Cloud Storage.
 terraform {
-  backend "gcs" {                                # The Google Cloud Storage backend
-    bucket = "bootstrap-5541-tfstate"           # The name of the bucket to store the state file
-    prefix = "production"                        # The path to the state file within the bucket
+  backend "gcs" {                             # The Google Cloud Storage backend
+    bucket = "project-id-placeholder-tfstate" # The name of the bucket to store the state file
+    prefix = "production"                     # The path to the state file within the bucket
     # Authentication uses Application Default Credentials (ADC) from Workload Identity Federation
   }
 }


### PR DESCRIPTION
## What and why was modified?

- Fixed GitHub Actions workflow permission validation errors by granting `id-token: write` to reusable workflow callers
- Moved sensitive backend.tf generation from open-source bootstrap script to deployment pipeline
- Backend configuration now generated dynamically at deployment time using GCP_PROJECT_ID secret
- Added backend.tf to .gitignore to prevent accidental commits of generated files

**Security improvements:**
- Project ID no longer exposed in bootstrap scripts that live in open-source repositories
- Configuration generated at deployment time ensures secrets stay in CI/CD, not in code
- Least-privilege approach: secrets only used where needed (workflow step environment)

## How was it modified?

### GitHub Actions Workflow Updates
- Added `id-token: write` permission to `deploy-kernel`, `deploy-people`, and `deploy-things` jobs
- These permissions are required by the reusable workflow that uses Workload Identity Federation for GCP authentication

### Terraform Backend Configuration
- Moved backend.tf generation from `teams/kernel/iac/bootstrap/project-setup.sh` to `.github/workflows/teams-kernel-workflows-deploy-team.yml`
- New workflow step "Generate Terraform Backend Configuration" runs before `terraform init`
- Uses shell heredoc with environment variable substitution to populate GCP_PROJECT_ID at runtime

### Git Configuration
- Added `backend.tf` to `.gitignore` alongside other Terraform-generated files (tfplan, tfstate, etc.)

## Reference links and evaluation steps

1. Review updated workflows in `.github/workflows/`:
   - `teams-kernel-workflows-deploy.yml` - Added permissions to deployment jobs
   - `teams-kernel-workflows-deploy-team.yml` - Added backend.tf generation step
   
2. Verify bootstrap script cleanup:
   - `teams/kernel/iac/bootstrap/project-setup.sh` - Backend generation removed
   
3. Test the deployment workflow:
   - Trigger a deployment workflow run
   - Verify backend.tf is generated with correct bucket name (contains GCP_PROJECT_ID)
   - Verify terraform init succeeds with generated configuration

---

## Experiment Record

| Field | Details |
|-------|---------|
| **Challenge** | Backend configuration was exposing GCP project ID in open-source bootstrap scripts |
| **Target** | Move sensitive configuration generation to CI/CD pipeline, keep bootstrap scripts open-source-safe |
| **Expected result** | Workflows validate without permission errors, backend.tf generated at deployment time using secrets |
| **Type of experiment** | Testing hypothesis |
| **What happened** | Added permissions to workflows, moved backend.tf generation to reusable workflow step, updated .gitignore |
| **What did we learn** | Reusable workflows require callers to grant all permissions they need; sensitive config belongs in CI/CD, not bootstrap |

## Next step

Consider extending this pattern to other environment configurations (e.g., people team, things team backend setups) to ensure consistent security practices across all team deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment jobs now allow OpenID Connect tokens for improved workflow security.
  * Deployment process requires a project identifier and will generate backend configuration dynamically during deploy.
  * Documentation updated with five new short-term insights and removal of older entries to refresh content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->